### PR TITLE
Add a couple of tests to verify correct osgi handling

### DIFF
--- a/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
+++ b/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
@@ -54,6 +54,12 @@ public class VersionTest
         assertThat( version.getMinorVersion(), equalTo( "01" ) );
         assertThat( version.getMicroVersion(), equalTo( "0" ) );
         assertThat( version.getQualifier(), equalTo( "beta2_SNAPSHOT_HELLO-1" ) );
+
+        version = new Version("1.2.3.4.Final-X");
+        assertThat( version.getMajorVersion(), equalTo( "1" ) );
+        assertThat( version.getMinorVersion(), equalTo( "2" ) );
+        assertThat( version.getMicroVersion(), equalTo( "3" ) );
+        assertThat( version.getQualifier(), equalTo( "4.Final-X" ) );
     }
 
     @Test
@@ -195,6 +201,10 @@ public class VersionTest
         version = new Version("1.2.0-SNAPSHOT");
         version.appendQualifierSuffix( "jboss-2" );
         assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.jboss-2-SNAPSHOT" ) );
+
+        version = new Version("1.2.3.4.GA.1");
+        version.appendQualifierSuffix( "jboss-1" );
+        assertThat( version.getOSGiVersionString(), equalTo( "1.2.3.4-GA-1-jboss-1" ) );
     }
 
     @Test

--- a/src/test/java/org/commonjava/maven/ext/manip/impl/VersioningCalculatorTest.java
+++ b/src/test/java/org/commonjava/maven/ext/manip/impl/VersioningCalculatorTest.java
@@ -489,6 +489,24 @@ public class VersioningCalculatorTest
     }
 
     @Test
+    public void applySerialSuffix_InvalidOSGi()
+        throws Exception
+    {
+        final Properties props = new Properties();
+
+        final String origVersion = "1.2.3.4.Final";
+        final String suffix = "foo-1";
+        final String newVersion = "1.2.3.4-Final-foo-1";
+
+        props.setProperty( VersioningState.VERSION_SUFFIX_SYSPROP, suffix );
+        setupSession( props );
+
+
+        final String result = calculate( origVersion );
+        assertThat( result, equalTo( newVersion ) );
+    }
+
+    @Test
     public void incrementExistingSerialSuffix()
         throws Exception
     {


### PR DESCRIPTION
Verify that the tool can correctly convert a version with two many "."s
to a valid OSGi version string.