### PR TITLE
[issue122] Fix cases with a major only version

### DIFF
--- a/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
+++ b/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
@@ -611,10 +611,11 @@ public class Version
     {
         int highestBuildNum = 0;
 
-        // Build version pattern regex
+        // Build version pattern regex, matches something like "<mmm>.<qualifier>.<buildnum>".
         StringBuffer versionPatternBuf = new StringBuffer();
         versionPatternBuf.append( "(" );
         versionPatternBuf.append( Pattern.quote( getOriginalMMM() ) );
+        versionPatternBuf.append( "(" + DELIMITER_REGEX + "0)*" ); // Match zeros appended to a major only version
         versionPatternBuf.append( ")?" );
         versionPatternBuf.append( DELIMITER_REGEX );
         if ( version.getQualifierBase() != null )
@@ -622,9 +623,7 @@ public class Version
             versionPatternBuf.append( Pattern.quote( version.getQualifierBase() ) );
             versionPatternBuf.append( DELIMITER_REGEX );
         }
-        versionPatternBuf.append( "(" );
-        versionPatternBuf.append( "\\d+" );
-        versionPatternBuf.append( ")" );
+        versionPatternBuf.append( "(\\d+)" );
         String candidatePatternStr = versionPatternBuf.toString();
 
         logger.debug( "Using pattern: '{}' to find compatible versions from metadata.", candidatePatternStr );
@@ -635,7 +634,7 @@ public class Version
             final Matcher candidateSuffixMatcher = candidateSuffixPattern.matcher( compareVersion );
             if ( candidateSuffixMatcher.matches() )
             {
-                String buildNumberStr = candidateSuffixMatcher.group( 2 );
+                String buildNumberStr = candidateSuffixMatcher.group( 3 );
                 int compareBuildNum = Integer.parseInt( buildNumberStr );
                 if ( compareBuildNum > highestBuildNum )
                 {

--- a/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
+++ b/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
@@ -269,13 +269,21 @@ public class VersionTest
     }
 
     @Test
-    @Ignore( "PENDING: https://github.com/release-engineering/pom-manipulation-ext/issues/122" )
     public void testZeroFill_FindHighestMatchingBuildNumber()
     {
         final Set<String> versionSet = new HashSet<String>();
-        final Version version = new Version( "7" );
+        final Version majorOnlyVersion = new Version( "7" );
+        majorOnlyVersion.appendQualifierSuffix( "redhat" );
+        System.out.println("OSGi version: " + majorOnlyVersion.getOSGiVersionString());
         versionSet.add( "7.0.0.redhat-2" );
-        assertThat( version.findHighestMatchingBuildNumber( version, versionSet ), equalTo( 2 ) );
+        assertThat( majorOnlyVersion.findHighestMatchingBuildNumber( majorOnlyVersion, versionSet ), equalTo( 2 ) );
+        versionSet.clear();
+
+        final Version majorMinorVersion = new Version( "7.1" );
+        majorMinorVersion.appendQualifierSuffix( "redhat" );
+        System.out.println("OSGi version: " + majorMinorVersion.getOSGiVersionString());
+        versionSet.add( "7.1.0.redhat-2" );
+        assertThat( majorMinorVersion.findHighestMatchingBuildNumber( majorMinorVersion, versionSet ), equalTo( 2 ) );
         versionSet.clear();
     }
     


### PR DESCRIPTION
If a simple major only version was previously converted to OSGi and then incremented
with a suffix, make sure we can match that in the existing set of versions in the repository.