### PR TITLE
disable addition of version-override properties, which uses VersionPropertyFormat

### DIFF
--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/DependencyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/DependencyManipulator.java
@@ -356,7 +356,7 @@ public class DependencyManipulator implements Manipulator
                 applyExplicitOverrides( versionPropertyUpdateMap, explicitOverrides, dependencies );
 
                 // Add/override a property to the build for each override
-                addVersionOverrideProperties( session, matchedOverrides, model.getProperties() );
+//                addVersionOverrideProperties( session, matchedOverrides, model.getProperties() );
 
                 if ( session.getState( DependencyState.class ).getOverrideTransitive() )
                 {
@@ -388,7 +388,7 @@ public class DependencyManipulator implements Manipulator
                         logger.debug( "New entry added to <DependencyManagement/> - {} : {} ", var, artifactVersion );
 
                         // Add/override a property to the build for each override
-                        addVersionOverrideProperties( session, nonMatchingVersionOverrides, model.getProperties() );
+//                        addVersionOverrideProperties( session, nonMatchingVersionOverrides, model.getProperties() );
                     }
 
                     dependencyManagement.getDependencies().addAll( 0, extraDeps );


### PR DESCRIPTION
...in anticipation of removal for this section of the code.

@rnc The build succeeds on my localhost after this change. Do you know if this section is really unused now, or if the tests are just a little light?

I'm happy to continue work on removal, but wanted to ping you about this first.