### PR TITLE
Use port-finder for REST mock server, to avoid problems in CI.

### DIFF
--- a/integration-test/src/test/java/org/commonjava/maven/ext/manip/CliTestUtils.java
+++ b/integration-test/src/test/java/org/commonjava/maven/ext/manip/CliTestUtils.java
@@ -17,10 +17,14 @@ package org.commonjava.maven.ext.manip;
 
 import groovy.lang.Binding;
 import groovy.util.GroovyScriptEngine;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.commonjava.maven.ext.manip.invoker.DefaultExecutionParser;
 import org.commonjava.maven.ext.manip.invoker.Execution;
 import org.commonjava.maven.ext.manip.invoker.ExecutionParser;
 import org.commonjava.maven.ext.manip.invoker.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.*;
@@ -45,6 +49,8 @@ public class CliTestUtils
             put( "maven.repo.local", LOCAL_REPO );
         }};
 
+    private static final java.lang.String REST_URL_PROPERTY = "restURL";
+
     /**
      * Run the same/similar execution to what invoker plugin would run.
      *
@@ -52,6 +58,19 @@ public class CliTestUtils
      * @throws Exception
      */
     public static void runLikeInvoker( String workingDir )
+            throws Exception
+    {
+        runLikeInvoker( workingDir, null );
+    }
+
+    /**
+     * Run the same/similar execution to what invoker plugin would run.
+     *
+     * @param workingDir - Working directory where the invoker properties are.
+     * @param restURL The URL to the REST server that manages versions, or null
+     * @throws Exception
+     */
+    public static void runLikeInvoker( String workingDir, String restURL )
         throws Exception
     {
         ExecutionParser executionParser = new DefaultExecutionParser( DefaultExecutionParser.DEFAULT_HANDLERS );
@@ -60,6 +79,13 @@ public class CliTestUtils
         // Execute
         for ( Execution e : executions )
         {
+            if ( restURL != null )
+            {
+                Logger logger = LoggerFactory.getLogger( CliTestUtils.class );
+                logger.info( "Resetting REST URL to: {}", restURL );
+                e.getJavaParams().put( REST_URL_PROPERTY, restURL );
+            }
+
             List<String> args = new ArrayList<String>();
             args.add( "-s" );
             args.add( getDefaultTestLocation( "settings.xml" ) );

--- a/integration-test/src/test/java/org/commonjava/maven/ext/manip/RESTIntegrationTest.java
+++ b/integration-test/src/test/java/org/commonjava/maven/ext/manip/RESTIntegrationTest.java
@@ -31,13 +31,13 @@ public class RESTIntegrationTest
     public void testRESTVersionDepManip() throws Exception
     {
         String test = getDefaultTestLocation( "rest-dependency-version-manip-child-module" );
-        runLikeInvoker( test );
+        runLikeInvoker( test, mockServer.getUrl() );
     }
 
     @Test
     public void testRESTVersionManip() throws Exception
     {
         String test = getDefaultTestLocation( "rest-version-manip-only" );
-        runLikeInvoker( test );
+        runLikeInvoker( test, mockServer.getUrl() );
     }
 }

--- a/io/src/main/java/org/commonjava/maven/ext/manip/rest/DefaultVersionTranslator.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/rest/DefaultVersionTranslator.java
@@ -58,7 +58,7 @@ public class DefaultVersionTranslator
         {
             throw new RestException(
                 String.format( "Request to server '%s' failed. Exception message: %s", this.endpointUrl,
-                               e.getMessage() ) );
+                               e.getMessage() ), e );
         }
 
         // Handle some corner cases (5xx, 4xx)

--- a/io/src/main/java/org/commonjava/maven/ext/manip/rest/exception/RestException.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/rest/exception/RestException.java
@@ -15,11 +15,21 @@
  */
 package org.commonjava.maven.ext.manip.rest.exception;
 
+import com.mashape.unirest.http.exceptions.UnirestException;
+
 /**
  * @author vdedik@redhat.com
  */
-public class RestException extends RuntimeException {
-    public RestException(String msg) {
-        super(msg);
+public class RestException
+        extends RuntimeException
+{
+    public RestException( String msg )
+    {
+        super( msg );
+    }
+
+    public RestException( String message, Throwable e )
+    {
+        super( message, e );
     }
 }

--- a/io/src/main/java/org/commonjava/maven/ext/manip/rest/mapper/ProjectVersionRefMapper.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/rest/mapper/ProjectVersionRefMapper.java
@@ -49,7 +49,7 @@ public class ProjectVersionRefMapper implements ObjectMapper
         }
         catch ( IOException e )
         {
-            throw new RestException( e.getMessage() );
+            throw new RestException( "Failed to read list-of-maps response from version server: " + e.getMessage(), e );
         }
 
         for ( Map<String, Object> gav: responseBody )
@@ -91,7 +91,7 @@ public class ProjectVersionRefMapper implements ObjectMapper
         }
         catch ( JsonProcessingException e )
         {
-            throw new RestException( e.getMessage() );
+            throw new RestException( "Failed to serialize version request: " + e.getMessage(), e );
         }
     }
 }

--- a/io/src/test/java/org/commonjava/maven/ext/manip/server/JettyHttpServer.java
+++ b/io/src/test/java/org/commonjava/maven/ext/manip/server/JettyHttpServer.java
@@ -28,10 +28,8 @@ import org.slf4j.LoggerFactory;
  * @author vdedik@redhat.com
  */
 public class JettyHttpServer
-    implements HttpServer
+        implements HttpServer
 {
-    public static final Integer DEFAULT_PORT = 8089;
-
     private Integer port;
 
     private final Server jettyServer;
@@ -40,12 +38,7 @@ public class JettyHttpServer
 
     public JettyHttpServer( Handler handler )
     {
-        this( handler, DEFAULT_PORT );
-    }
-
-    public JettyHttpServer( Handler handler, Integer port )
-    {
-        this.port = port;
+        this.port = PortFinder.findOpenPort( 16 );
         this.handler = handler;
         this.jettyServer = createAndStartJetty( port );
     }

--- a/io/src/test/java/org/commonjava/maven/ext/manip/server/PortFinder.java
+++ b/io/src/test/java/org/commonjava/maven/ext/manip/server/PortFinder.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.ext.manip.server;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Random;
+
+public final class PortFinder
+{
+    private static final Random RANDOM = new Random();
+
+    private PortFinder()
+    {
+    }
+
+    public static int findOpenPort( final int maxTries )
+    {
+        for ( int i = 0; i < maxTries; i++ )
+        {
+            final int port = 1024 + ( Math.abs( RANDOM.nextInt() ) % 30000 );
+            ServerSocket sock = null;
+            try
+            {
+                sock = new ServerSocket( port );
+                return port;
+            }
+            catch ( final IOException e )
+            {
+            }
+            finally
+            {
+                IOUtils.closeQuietly( sock );
+            }
+        }
+
+        throw new IllegalStateException( "Cannot find open port after " + maxTries + " attempts." );
+    }
+
+}


### PR DESCRIPTION
Also, wrap lower exceptions when throwing at a higher level (looking at you, DefaultVersionTranslator). That way we don't lose the stack trace