### PR TITLE
Use system properties to figure out what JVM is in use, so CI system …

### DIFF
--- a/integration-test/src/test/java/org/commonjava/maven/ext/manip/CliTestUtils.java
+++ b/integration-test/src/test/java/org/commonjava/maven/ext/manip/CliTestUtils.java
@@ -177,9 +177,27 @@ public class CliTestUtils
         String stringArgs = toArguments( args );
         String stringParams = toJavaParams( params );
         String command =
-            String.format( "java -jar %s/pom-manipulation-cli.jar %s %s", BUILD_DIR, stringParams, stringArgs );
+            String.format( "%s -jar %s/pom-manipulation-cli.jar %s %s", getJavaBin().getAbsolutePath(), BUILD_DIR, stringParams, stringArgs );
 
         return runCommandAndWait( command, workingDir, null );
+    }
+
+    public static File getJavaBin()
+    {
+        String javaHome = System.getProperty( "java.home" );
+        File dir = new File( javaHome );
+        String subPath = "bin/java";
+        if ( javaHome.endsWith( "jre" ) )
+        {
+            File jvm = dir.getParentFile();
+            File jvmExe = new File( jvm, subPath );
+            if ( jvmExe.exists() )
+            {
+                return jvmExe;
+            }
+        }
+
+        return new File( dir, subPath );
     }
 
     /**

--- a/integration-test/src/test/java/org/commonjava/maven/ext/manip/RESTIntegrationTest.java
+++ b/integration-test/src/test/java/org/commonjava/maven/ext/manip/RESTIntegrationTest.java
@@ -19,6 +19,8 @@ import org.commonjava.maven.ext.manip.rest.rule.MockServer;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.io.File;
+
 import static org.commonjava.maven.ext.manip.CliTestUtils.getDefaultTestLocation;
 import static org.commonjava.maven.ext.manip.CliTestUtils.runLikeInvoker;
 


### PR DESCRIPTION
…builds will fork the right JVM for integration tests.