### PR TITLE
Check for null version before trying to resolve property

### DIFF
--- a/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
@@ -205,6 +205,10 @@ public final class PropertiesUtils
                                          String newVersion, Object originalType )
                     throws ManipulationException
     {
+        if (oldVersion == null) {
+            return false;
+        }
+
         boolean result = false;
         // TODO: Handle the scenario where the version might be ${....}${....}
         if ( oldVersion.startsWith( "${" ) )

--- a/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
@@ -149,6 +149,10 @@ public final class PropertiesUtils
      */
     public static boolean checkStrictValue( ManipulationSession session, String oldValue, String newValue )
     {
+        if (oldValue == null || newValue == null) {
+            return false;
+        }
+
         // New value might be e.g. 3.1-rebuild-1 or 3.1.0.rebuild-1 (i.e. it *might* be OSGi compliant).
         final VersioningState state = session.getState( VersioningState.class );
         final Version v = new Version( oldValue );
@@ -184,7 +188,7 @@ public final class PropertiesUtils
         // We compare both an OSGi'ied oldVersion and the non-OSGi version against the possible new version (which has
         // had its suffix stripped) in order to check whether its a valid change.
         boolean result = false;
-        if ( oldValue != null && oldValue.equals( newVersion ) || osgiVersion.equals( newVersion ))
+        if ( oldValue.equals( newVersion ) || osgiVersion.equals( newVersion ))
         {
             result = true;
         }
@@ -205,13 +209,9 @@ public final class PropertiesUtils
                                          String newVersion, Object originalType )
                     throws ManipulationException
     {
-        if (oldVersion == null) {
-            return false;
-        }
-
         boolean result = false;
         // TODO: Handle the scenario where the version might be ${....}${....}
-        if ( oldVersion.startsWith( "${" ) )
+        if ( oldVersion != null && oldVersion.startsWith( "${" ) )
         {
             final int endIndex = oldVersion.indexOf( '}' );
             final String oldProperty = oldVersion.substring( 2, endIndex );

--- a/core/src/test/java/org/commonjava/maven/ext/manip/util/PropertiesUtilTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/manip/util/PropertiesUtilTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.ext.manip.util;
+
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+
+import junit.framework.TestCase;
+
+import org.commonjava.maven.ext.manip.ManipulationSession;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+public class PropertiesUtilTest extends TestCase
+{
+
+    @Test
+    public void testCheckStrictValue() throws Exception
+    {
+        ManipulationSession session = new ManipulationSession();
+        assertFalse(PropertiesUtils.checkStrictValue(session, null, "1.0"));
+        assertFalse(PropertiesUtils.checkStrictValue(session, "1.0", null));
+    }
+
+    @Test
+    public void testCacheProperty() throws Exception
+    {
+        Map propertyMap = new HashMap();
+        
+        assertFalse(PropertiesUtils.cacheProperty(propertyMap, null, "2.0", null));
+        assertFalse(PropertiesUtils.cacheProperty(propertyMap, "1.0", "2.0", null));
+        assertTrue(PropertiesUtils.cacheProperty(propertyMap, "${version.org.jboss}", "2.0", null));
+    }
+
+}


### PR DESCRIPTION
Checks the value of oldVersion parameter before trying to parse the string
to avoid NullPointerException