### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/DependencyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/DependencyManipulator.java
@@ -166,7 +166,7 @@ public class DependencyManipulator implements Manipulator
         {
             final Model model = project.getModel();
 
-            if ( overrides.size() > 0 || state.getDependencyExclusions().size() > 0)
+            if (!overrides.isEmpty() || !state.getDependencyExclusions().isEmpty())
             {
                 apply( session, project, model, overrides );
 
@@ -175,7 +175,7 @@ public class DependencyManipulator implements Manipulator
         }
 
         // If we've changed something now update any old properties with the new values.
-        if ( result.size() > 0 )
+        if (!result.isEmpty())
         {
             logger.info ("Iterating for standard overrides...");
             for ( final String key : versionPropertyUpdateMap.keySet() )
@@ -647,7 +647,7 @@ public class DependencyManipulator implements Manipulator
 
                     if ( moduleGA.equals( projectGA ) )
                     {
-                        if ( currentValue != null && currentValue.length() > 0 )
+                        if ( currentValue != null && !currentValue.isEmpty())
                         {
                             explicitOverrides.put( SimpleProjectRef.parse( artifactGA ), currentValue );
                             logger.debug( "Overriding module dependency for {} with {} : {}", moduleGA, artifactGA,
@@ -682,7 +682,7 @@ public class DependencyManipulator implements Manipulator
                     }
 
                     // I think this is only used for e.g. dependencyExclusion.groupId:artifactId@*=<explicitVersion>
-                    if ( currentValue != null && currentValue.length() > 0 )
+                    if ( currentValue != null && !currentValue.isEmpty())
                     {
                         logger.debug( "Overriding module dependency for {} with {} : {}", projectGA, artifactGA,
                                       currentValue );

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/DistributionEnforcingManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/DistributionEnforcingManipulator.java
@@ -233,7 +233,7 @@ public class DistributionEnforcingManipulator
                         textVal = textVal.trim();
                     }
 
-                    if ( textVal.length() > 0 )
+                    if (!textVal.isEmpty())
                     {
                         skipSetting = Boolean.parseBoolean( textVal );
                         baseSkipSetting = skipSetting;

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/PluginManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/PluginManipulator.java
@@ -111,7 +111,7 @@ public class PluginManipulator
         {
             final Model model = project.getModel();
 
-            if ( overrides.size() > 0 )
+            if (!overrides.isEmpty())
             {
                 apply( session, project, model, overrides );
 
@@ -119,7 +119,7 @@ public class PluginManipulator
             }
         }
         // If we've changed something now update any old properties with the new values.
-        if ( changed.size() > 0 )
+        if (!changed.isEmpty())
         {
             logger.info( "Iterating for standard overrides..." );
             for ( final String key : state.getVersionPropertyOverrides().keySet() )
@@ -304,7 +304,7 @@ public class PluginManipulator
                     }
                 }
 
-                if (override.getDependencies().size() > 0)
+                if (!override.getDependencies().isEmpty())
                 {
                     logger.debug( "Checking original plugin dependencies versus override" );
                     // First, remove any Dependency from the original Plugin if the GA exists in the override.
@@ -333,7 +333,7 @@ public class PluginManipulator
                 String oldVersion = plugin.getVersion();
                 // Always force the version in a pluginMgmt block or set the version if there is an existing
                 // one in build/plugins section.
-                if ( override.getVersion() != null && override.getVersion().length() > 0 )
+                if ( override.getVersion() != null && !override.getVersion().isEmpty())
                 {
                     if ( ! PropertiesUtils.cacheProperty( pluginState.getVersionPropertyOverrides(), oldVersion, override.getVersion(), plugin ))
                     {

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProjectVersionEnforcingManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProjectVersionEnforcingManipulator.java
@@ -119,7 +119,7 @@ public class ProjectVersionEnforcingManipulator
                 }
             }
         }
-        if ( changed.size() > 0 )
+        if (!changed.isEmpty())
         {
             logger.warn( "Using ${project.version} in pom files may lead to unexpected errors with inheritance." );
         }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/PropertyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/PropertyManipulator.java
@@ -88,7 +88,7 @@ public class PropertyManipulator
         {
             final Model model = project.getModel();
 
-            if ( overrides.size() > 0 )
+            if (!overrides.isEmpty())
             {
                 // Only inject the new properties at the top level.
                 if ( project.isInheritanceRoot() )
@@ -107,7 +107,7 @@ public class PropertyManipulator
                     Set<String> keyClone = new HashSet(model.getProperties().keySet());
                     keyClone.retainAll( overrides.keySet() );
 
-                    if ( keyClone.size() > 0 )
+                    if (!keyClone.isEmpty())
                     {
                         final Iterator<String> keys = keyClone.iterator();
                         while (keys.hasNext())

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/RESTManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/RESTManipulator.java
@@ -184,7 +184,7 @@ public class RESTManipulator implements Manipulator
         Set<String> activeModules = new HashSet<String>();
         boolean scanAll = false;
 
-        if (activeProfiles != null && activeProfiles.size() > 0)
+        if (activeProfiles != null && !activeProfiles.isEmpty())
         {
             for ( final Project project : projects )
             {
@@ -198,7 +198,7 @@ public class RESTManipulator implements Manipulator
                     {
                         for ( Profile p : profiles )
                         {
-                            if ( activeProfiles != null && activeProfiles.size() > 0 && activeProfiles.contains(p.getId() ) )
+                            if ( activeProfiles != null && !activeProfiles.isEmpty() && activeProfiles.contains(p.getId() ) )
                             {
                                 activeModules.addAll( p.getModules() );
                             }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/VersionCalculator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/VersionCalculator.java
@@ -207,7 +207,7 @@ public class VersionCalculator
             if ( rm != null)
             {
                 // If the REST Client has prepopulated incremental data use that instead of the examining the repository.
-                if (rm.size() > 0)
+                if (!rm.isEmpty())
                 {
                     // Use preloaded metadata from remote repository, loaded via a REST Call.
                     if (rm.get( new SimpleProjectRef( groupId, artifactId ) ) != null)

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/DependencyState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/DependencyState.java
@@ -96,7 +96,7 @@ public class DependencyState
     {
         return ( ( remoteBOMdepMgmt != null && !remoteBOMdepMgmt.isEmpty()   ) ||
                  ( remoteRESTdepMgmt != null && !remoteRESTdepMgmt.isEmpty() ) ||
-                 ( dependencyExclusions.size() > 0 ) );
+                 (!dependencyExclusions.isEmpty()) );
     }
 
     public List<ProjectVersionRef> getRemoteBOMDepMgmt()

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/ProfileInjectionState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/ProfileInjectionState.java
@@ -45,7 +45,7 @@ public class ProfileInjectionState
     {
         final String gav = userProps.getProperty( PROFILE_INJECTION_PROPERTY );
         ProjectVersionRef ref = null;
-        if ( gav != null && gav.length() > 0 )
+        if ( gav != null && !gav.isEmpty())
         {
             try
             {

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/RESTState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/RESTState.java
@@ -44,7 +44,7 @@ public class RESTState implements State
     @Override
     public boolean isEnabled()
     {
-        return restURL != null && restURL.length() > 0;
+        return restURL != null && !restURL.isEmpty();
     }
 
     /**

--- a/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
@@ -161,11 +161,11 @@ public final class PropertiesUtils
         String suffix = null;
         String osgiVersion = v.getOSGiVersionString();
 
-        if ( state.getIncrementalSerialSuffix() != null && state.getIncrementalSerialSuffix().length() > 0)
+        if ( state.getIncrementalSerialSuffix() != null && !state.getIncrementalSerialSuffix().isEmpty())
         {
             suffix = state.getIncrementalSerialSuffix();
         }
-        else if ( state.getSuffix() != null && state.getSuffix().length() > 0)
+        else if ( state.getSuffix() != null && !state.getSuffix().isEmpty())
         {
             suffix = state.getSuffix().substring( 0, state.getSuffix().indexOf( '-' ) );
         }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/util/WildcardMap.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/util/WildcardMap.java
@@ -58,7 +58,7 @@ public class WildcardMap
 
         LinkedHashMap vMap = map.get(groupId);
 
-        if ( vMap == null || vMap.size() == 0)
+        if ( vMap == null || vMap.isEmpty())
         {
             result = false;
         }
@@ -97,7 +97,7 @@ public class WildcardMap
         if ( WILDCARD.equals(artifactId))
         {
             // Erase any previous mappings.
-            if ( vMap.size() > 0)
+            if (!vMap.isEmpty())
             {
                 logger.warn ("Emptying map with keys " + vMap.keySet() + " as replacing with wildcard mapping " + key);
             }

--- a/io/src/main/java/org/commonjava/maven/ext/manip/io/ModelIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/io/ModelIO.java
@@ -283,7 +283,7 @@ public class ModelIO
             {
                 String replacement = resolveProperty ( userProperties, model.getProperties(), child.getValue() );
 
-                if (replacement != null && replacement.length() > 0)
+                if (replacement != null && !replacement.isEmpty())
                 {
                     logger.debug( "Replacing child value " + child.getValue() + " with " + replacement );
                     child.setValue( replacement );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat