### PR TITLE
squid:S1941 - Variables should not be declared before they are relevant

### DIFF
--- a/common/src/main/java/org/commonjava/maven/ext/manip/model/Project.java
+++ b/common/src/main/java/org/commonjava/maven/ext/manip/model/Project.java
@@ -451,7 +451,6 @@ public class Project
                     throws ManipulationException
     {
         String g = model.getGroupId();
-        final String a = model.getArtifactId();
         String v = model.getVersion();
 
         if ( g == null || v == null )
@@ -473,7 +472,7 @@ public class Project
 
         }
 
-
+        final String a = model.getArtifactId();
         return new SimpleProjectVersionRef( g, a, v );
     }
 

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProjectVersioningManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProjectVersioningManipulator.java
@@ -166,15 +166,13 @@ public class ProjectVersioningManipulator
                                               final Project project, final VersioningState state )
         throws ManipulationException
     {
-        boolean changed = false;
-
-        final Model model = project.getModel();
 
         if ( !state.hasVersionsByGAVMap() )
         {
             return false;
         }
 
+        final Model model = project.getModel();
         if ( model == null )
         {
             return false;
@@ -196,6 +194,7 @@ public class ProjectVersioningManipulator
             v = parent.getVersion();
         }
 
+        boolean changed = false;
         Map<ProjectVersionRef, String> versionsByGAV = state.getVersionsByGAVMap();
         // If the parent version is defined, it might be necessary to change it
         // If the parent version is not defined, it will be taken automatically from the project version
@@ -375,14 +374,14 @@ public class ProjectVersioningManipulator
     {
         // TODO: Handle the scenario where the version might be ${....}${....}
         final int endIndex = version.indexOf( '}' );
-        final String property = version.substring( 2, endIndex );
 
         if ( endIndex != version.length() - 1 )
         {
             throw new ManipulationException( "NYI : handling for versions (" + version
                                                              + ") with multiple embedded properties is NYI. " );
         }
-        return property;
+
+        return version.substring( 2, endIndex );
     }
 
     @Override

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/RESTManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/RESTManipulator.java
@@ -75,9 +75,6 @@ public class RESTManipulator implements Manipulator
                     throws ManipulationException
     {
         final RESTState state = session.getState( RESTState.class );
-        final ArrayList<ProjectVersionRef> restParam = new ArrayList<ProjectVersionRef>();
-
-        Map<ProjectVersionRef, String> restResult;
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
@@ -85,6 +82,7 @@ public class RESTManipulator implements Manipulator
             return;
         }
 
+        final ArrayList<ProjectVersionRef> restParam = new ArrayList<ProjectVersionRef>();
         for ( final Project project : projects )
         {
             // TODO: Check this : For the rest API I think we need to check every project GA not just inheritance root.
@@ -104,6 +102,7 @@ public class RESTManipulator implements Manipulator
         logger.debug ("Passing the following into the REST client api {} ", restParam);
         logger.info ("Calling REST client...");
         long start = System.nanoTime();
+        Map<ProjectVersionRef, String> restResult;
 
         try
         {

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
@@ -164,7 +164,6 @@ public class Version
      */
     private int getQualifierIndex( String version )
     {
-        final int QUALIFIER_NOT_FOUND = version.length();
 
         int qualifierIndex = 0;
         int delimiterCount = 0;
@@ -186,7 +185,7 @@ public class Version
                 return qualifierIndex;
             }
         }
-        return QUALIFIER_NOT_FOUND;
+        return version.length();
     }
 
     /**

--- a/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
@@ -256,13 +256,14 @@ public final class PropertiesUtils
         if (version.startsWith( "${" ) )
         {
             final int endIndex = version.indexOf( '}' );
-            final String property = version.substring( 2, endIndex );
 
             if ( endIndex != version.length() - 1 )
             {
                 throw new ManipulationException( "NYI : handling for versions (" + version
                                                                  + ") with multiple embedded properties is NYI. " );
             }
+
+            final String property = version.substring( 2, endIndex );
             for ( Project p : projects)
             {
                 logger.trace( "Scanning {} for property {} and found {} ", p, property, p.getModel().getProperties() );

--- a/io/src/main/java/org/commonjava/maven/ext/manip/rest/mapper/ProjectVersionRefMapper.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/rest/mapper/ProjectVersionRefMapper.java
@@ -42,7 +42,6 @@ public class ProjectVersionRefMapper implements ObjectMapper
     @Override
     public Map<ProjectVersionRef, String> readValue( String s )
     {
-        List<Map<String, Object>> responseBody;
         Map<ProjectVersionRef, String> result = new HashMap<ProjectVersionRef, String>();
 
         // Workaround for https://github.com/Mashape/unirest-java/issues/122
@@ -54,6 +53,8 @@ public class ProjectVersionRefMapper implements ObjectMapper
             logger.error( "Read HTML string '{}' rather than a JSON stream.", s );
             return result;
         }
+
+        List<Map<String, Object>> responseBody;
         try
         {
             responseBody = objectMapper.readValue( s, List.class );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1941 - Variables should not be declared before they are relevant

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941

Please let me know if you have any questions.

M-Ezzat