### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/JSONState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/JSONState.java
@@ -100,9 +100,9 @@ public class JSONState
 
     public final static class JSONOperation
     {
-        String file;
-        String xpath;
-        String update;
+        private String file;
+        private String xpath;
+        private String update;
 
         public JSONOperation ( String file, String xpath, String update)
         {

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/XMLState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/XMLState.java
@@ -100,9 +100,9 @@ public class XMLState
 
     public final static class XMLOperation
     {
-        String file;
-        String xpath;
-        String update;
+        private String file;
+        private String xpath;
+        private String update;
 
         public XMLOperation ( String file, String xpath, String update)
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat