### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/io/src/main/java/org/commonjava/maven/ext/manip/io/JSONIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/io/JSONIO.java
@@ -30,8 +30,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 
 @Component( role = JSONIO.class )
 public class JSONIO
@@ -70,7 +72,8 @@ public class JSONIO
         {
             String pretty = mapper.writer(dpp).writeValueAsString( mapper.readValue( contents, Object.class ) );
 
-            try ( FileWriter p = new FileWriter( target ) )
+            FileOutputStream fileOutputStream = new FileOutputStream(target);
+            try (OutputStreamWriter p = new OutputStreamWriter(fileOutputStream, StandardCharsets.UTF_8) )
             {
                 p.write( pretty );
                 p.append( '\n' );

--- a/io/src/main/java/org/commonjava/maven/ext/manip/io/SettingsIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/io/SettingsIO.java
@@ -47,7 +47,7 @@ public class SettingsIO
     {
         try
         {
-            PrintWriter printWriter = new PrintWriter( settingsFile );
+            PrintWriter printWriter = new PrintWriter( settingsFile, "UTF-8" );
             new SettingsXpp3Writer().write( printWriter, settings );
         }
         catch ( IOException e )

--- a/io/src/main/java/org/commonjava/maven/ext/manip/resolver/GalleyAPIWrapper.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/resolver/GalleyAPIWrapper.java
@@ -16,6 +16,7 @@
 package org.commonjava.maven.ext.manip.resolver;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -73,14 +74,14 @@ public class GalleyAPIWrapper
         throws GalleyMavenXMLException
     {
         return infra.getXml()
-                    .parseDocument( xml, new ByteArrayInputStream( xml.getBytes() ) );
+                    .parseDocument( xml, new ByteArrayInputStream( xml.getBytes(StandardCharsets.UTF_8) ) );
     }
 
     public MavenXmlView<ProjectRef> parseXmlView( final String xml )
         throws GalleyMavenXMLException
     {
         final Document document = infra.getXml()
-                                       .parseDocument( xml, new ByteArrayInputStream( xml.getBytes() ) );
+                                       .parseDocument( xml, new ByteArrayInputStream( xml.getBytes(StandardCharsets.UTF_8) ) );
 
         final DocRef<ProjectRef> ref = new DocRef<ProjectRef>( new SimpleProjectRef( "unknown", "unknown" ), xml, document );
         return new MavenXmlView<>( Collections.singletonList( ref ), infra.getXPath(), infra.getXml() );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat