### PR TITLE
squid:S2864 - "entrySet()" should be iterated when both the key and v…

### DIFF
--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/RelocationState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/RelocationState.java
@@ -64,9 +64,9 @@ public class RelocationState
         // post-process this into something useful i.e. establish whether we are relocating groupIds and artifactIds.
         Map<String,String> propRelocs = PropertiesUtils.getPropertiesByPrefix( userProps, DEPENDENCY_RELOCATIONS );
 
-        for (String key : propRelocs.keySet())
+        for ( Map.Entry<String, String> entry : propRelocs.entrySet() )
         {
-            String[] split = key.split( ":", 3 );
+            String[] split = entry.getKey().split( ":", 3 );
             if ( split.length != 3 )
             {
                 throw new ManipulationException(
@@ -108,7 +108,7 @@ public class RelocationState
                                 groupId, newGroupId );
             }
 
-            String version = ( isEmpty( propRelocs.get( key ) ) ? WildcardMap.WILDCARD : propRelocs.get( key ) );
+            String version = ( isEmpty( entry.getValue() ) ? WildcardMap.WILDCARD : entry.getValue() );
 
             logger.debug( "Relocation found oldGroupId '{}' : oldArtifactId '{}' -> newGroupId '{}' : newArtifactId '{}' and version '{}' ",
                           groupId, artifactId, newGroupId, newArtifactId, version );

--- a/io/src/main/java/org/commonjava/maven/ext/manip/io/ModelIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/io/ModelIO.java
@@ -261,16 +261,16 @@ public class ModelIO
 
         // The list of pluginOverridesPomView may be larger than those in current model pluginMgtm. Dummy up an extra
         // set of plugins with versions to handle those.
-        for (ProjectRef pr : pluginOverridesPomView.keySet())
+        for ( Map.Entry<ProjectRef, ProjectVersionRef> entry : pluginOverridesPomView.entrySet() )
         {
             Plugin p = new Plugin();
-            p.setArtifactId( pr.getArtifactId() );
-            p.setGroupId( pr.getGroupId() );
-            p.setVersion( pluginOverridesPomView.get( pr ).getVersionString() );
+            p.setArtifactId( entry.getKey().getArtifactId() );
+            p.setGroupId( entry.getKey().getGroupId() );
+            p.setVersion( entry.getValue().getVersionString() );
 
-            pluginOverrides.put( pr, p );
+            pluginOverrides.put( entry.getKey(), p );
 
-            logger.debug( "Added plugin override for: " + pr.toString() + ":" + p.getVersion() );
+            logger.debug( "Added plugin override for: " + entry.getKey().toString() + ":" + p.getVersion() );
         }
 
         // TODO: active profiles!


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat