### PR TITLE
Cleanup - squid:S1312 - Loggers should be "private static final" and …

### DIFF
--- a/cli/src/main/java/org/commonjava/maven/ext/manip/Cli.java
+++ b/cli/src/main/java/org/commonjava/maven/ext/manip/Cli.java
@@ -87,7 +87,7 @@ public class Cli
     private static final File DEFAULT_GLOBAL_SETTINGS_FILE =
         new File( System.getProperty( "maven.home", System.getProperty( "user.dir", "" ) ), "conf/settings.xml" );
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( Cli.class );
 
     private ManipulationSession session;
 
@@ -183,7 +183,7 @@ public class Cli
         }
         catch ( ParseException e )
         {
-            logger.debug( "Caught problem parsing ", e );
+            LOGGER.debug( "Caught problem parsing ", e );
             System.err.println( e.getMessage() );
 
             HelpFormatter formatter = new HelpFormatter();
@@ -256,18 +256,18 @@ public class Cli
 
         if ( !session.isEnabled() )
         {
-            logger.info( "Manipulation engine disabled via command-line option" );
+            LOGGER.info( "Manipulation engine disabled via command-line option" );
             return 1;
         }
         if ( !target.exists() )
         {
-            logger.info( "Manipulation engine disabled. No project found." );
+            LOGGER.info( "Manipulation engine disabled. No project found." );
             return 1;
         }
         // Don't bother skipping if we're just trying to analyse deps.
         else if ( new File( target.getParentFile(), ManipulationManager.MARKER_FILE ).exists() && !cmd.hasOption( 'p' ) )
         {
-            logger.info( "Skipping manipulation as previous execution found." );
+            LOGGER.info( "Skipping manipulation as previous execution found." );
             return 0;
         }
         try
@@ -291,7 +291,7 @@ public class Cli
         }
         catch ( ManipulationException e )
         {
-            logger.error( "POM Manipulation failed: Unable to read config file ", e );
+            LOGGER.error( "POM Manipulation failed: Unable to read config file ", e );
             return 1;
         }
 
@@ -312,12 +312,12 @@ public class Cli
                 Document doc = xmlIO.parseXML( new File ( params[0] ) );
                 XPath xPath = XPathFactory.newInstance().newXPath();
                 NodeList nodeList = (NodeList) xPath.evaluate( params[1], doc, XPathConstants.NODESET);
-                logger.info ("Found {} node", nodeList.getLength());
+                LOGGER.info ("Found {} node", nodeList.getLength());
 
                 for ( int i = 0; i < nodeList.getLength(); i++)
                 {
                     Node node = nodeList.item( i );
-                    logger.info  ("Found node {} and value {} ", node.getNodeName(), node.getTextContent());
+                    LOGGER.info  ("Found node {} and value {} ", node.getNodeName(), node.getTextContent());
                 }
             }
             else if ( cmd.hasOption( 'p' ) || cmd.hasOption( "printGAVTC" ) || cmd.hasOption( "printUnusedDepMgmt" ))
@@ -329,7 +329,7 @@ public class Cli
                     Collections.addAll( activeProfiles, cmd.getOptionValue( 'P' ).split( "," ) );
                 }
                 Set<ArtifactRef> ts = RESTManipulator.establishAllDependencies( pomIO.parseProject( session.getPom() ), activeProfiles );
-                logger.info( "Found {} dependencies.", ts.size() );
+                LOGGER.info( "Found {} dependencies.", ts.size() );
                 File output = null;
 
                 if ( cmd.hasOption( 'o' ) )
@@ -340,7 +340,7 @@ public class Cli
                 if ( cmd.hasOption( "printUnusedDepMgmt" ) )
                 {
                     Set<ArtifactRef> nonMangedDeps = RESTManipulator.establishNonManagedDependencies( pomIO.parseProject( session.getPom() ), activeProfiles );
-                    logger.info( "Found {} non-managed dependencies.", nonMangedDeps.size() );
+                    LOGGER.info( "Found {} non-managed dependencies.", nonMangedDeps.size() );
                     // As the managed dependencies may have versions versus the non-managed strip off the versions to see what is left.
                     Set<ProjectRef> tsNoV = new TreeSet<>(  );
                     for ( ArtifactRef ar : ts)
@@ -408,18 +408,18 @@ public class Cli
         }
         catch ( ManipulationException e )
         {
-            logger.error( "POM Manipulation failed: Unable to parse projects ", e );
+            LOGGER.error( "POM Manipulation failed: Unable to parse projects ", e );
             return 1;
         }
         catch ( RestException e )
         {
-            logger.error ( "POM Manipulation failed with message {} ", e.getMessage () );
-            logger.trace ( "Exception trace is", e);
+            LOGGER.error ( "POM Manipulation failed with message {} ", e.getMessage () );
+            LOGGER.trace ( "Exception trace is", e);
             return 1;
         }
         catch ( Exception e )
         {
-            logger.error( "POM Manipulation failed.", e );
+            LOGGER.error( "POM Manipulation failed.", e );
             return 1;
         }
         return 0;
@@ -466,26 +466,26 @@ public class Cli
         }
         catch ( ComponentLookupException e )
         {
-            logger.debug( "Caught problem instantiating ", e );
+            LOGGER.debug( "Caught problem instantiating ", e );
             System.err.println( "Unable to start Cli subsystem" );
             System.exit( 1 );
             e.printStackTrace();
         }
         catch ( PlexusContainerException e )
         {
-            logger.debug( "Caught problem instantiating ", e );
+            LOGGER.debug( "Caught problem instantiating ", e );
             System.err.println( "Unable to start Cli subsystem" );
             System.exit( 1 );
         }
         catch ( SettingsBuildingException e )
         {
-            logger.debug( "Caught problem parsing settings file ", e );
+            LOGGER.debug( "Caught problem parsing settings file ", e );
             System.err.println( "Unable to parse settings.xml file" );
             System.exit( 1 );
         }
         catch ( MavenExecutionRequestPopulationException e )
         {
-            logger.debug( "Caught problem populating maven request from settings file ", e );
+            LOGGER.debug( "Caught problem populating maven request from settings file ", e );
             System.err.println( "Unable to create maven execution request from settings.xml file" );
             System.exit( 1 );
         }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/ManipulationManager.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/ManipulationManager.java
@@ -59,7 +59,7 @@ public class ManipulationManager
 
     static final String MARKER_FILE =  MARKER_PATH + File.separatorChar + "pom-manip-ext-marker.txt";
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ManipulationManager.class );
 
     @Requirement
     private ProjectBuilder projectBuilder;
@@ -105,7 +105,7 @@ public class ManipulationManager
 
         for ( final Manipulator manipulator : orderedManipulators )
         {
-            logger.debug( "Initialising manipulator " + manipulator.getClass()
+            LOGGER.debug( "Initialising manipulator " + manipulator.getClass()
                                                                    .getSimpleName() );
             manipulator.init( session );
         }
@@ -126,7 +126,7 @@ public class ManipulationManager
 
         for ( final Project project : projects )
         {
-            logger.debug( "Got " + project + " (POM: " + project.getPom() + ")" );
+            LOGGER.debug( "Got " + project + " (POM: " + project.getPom() + ")" );
         }
 
         Set<Project> changed = applyManipulations( projects, session );
@@ -134,7 +134,7 @@ public class ManipulationManager
         // Create a marker file if we made some changes to prevent duplicate runs.
         if ( !changed.isEmpty() )
         {
-            logger.info( "Maven-Manipulation-Extension: Rewrite changed: " + projects );
+            LOGGER.info( "Maven-Manipulation-Extension: Rewrite changed: " + projects );
             pomIO.rewritePOMs( changed );
 
             try
@@ -155,7 +155,7 @@ public class ManipulationManager
         {
             e.finish();
         }
-        logger.info( "Maven-Manipulation-Extension: Finished." );
+        LOGGER.info( "Maven-Manipulation-Extension: Finished." );
     }
 
     /**
@@ -204,7 +204,7 @@ public class ManipulationManager
 
         if ( changed.isEmpty() )
         {
-            logger.info( "Maven-Manipulation-Extension: No changes." );
+            LOGGER.info( "Maven-Manipulation-Extension: No changes." );
         }
 
         return changed;

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/DependencyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/DependencyManipulator.java
@@ -62,7 +62,7 @@ import static org.commonjava.maven.ext.manip.util.IdUtils.gav;
 @Component( role = Manipulator.class, hint = "project-dependency-manipulator" )
 public class DependencyManipulator implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( DependencyManipulator.class );
 
     /**
      * Used to store mappings of old property to new version for explicit overrides.
@@ -109,7 +109,7 @@ public class DependencyManipulator implements Manipulator
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
         return internalApplyChanges( projects, session, loadRemoteOverrides( state ) );
@@ -177,7 +177,7 @@ public class DependencyManipulator implements Manipulator
         // If we've changed something now update any old properties with the new values.
         if (!result.isEmpty())
         {
-            logger.info ("Iterating for standard overrides...");
+            LOGGER.info ("Iterating for standard overrides...");
             for ( final Map.Entry<String, String> entry : versionPropertyUpdateMap.entrySet() )
             {
                 PropertiesUtils.PropertyUpdate found = PropertiesUtils.updateProperties( session, result, false, entry.getKey(), entry.getValue());
@@ -187,18 +187,18 @@ public class DependencyManipulator implements Manipulator
                     // Problem in this scenario is that we know we have a property update map but we have not found a
                     // property to update. Its possible this property has been inherited from a parent. Override in the
                     // top pom for safety.
-                    logger.info( "Unable to find a property for {} to update", entry.getKey());
+                    LOGGER.info( "Unable to find a property for {} to update", entry.getKey());
                     for ( final Project p : result )
                     {
                         if ( p.isInheritanceRoot() )
                         {
-                            logger.info( "Adding property {} with {} ", entry.getKey(), entry.getValue() );
+                            LOGGER.info( "Adding property {} with {} ", entry.getKey(), entry.getValue() );
                             p.getModel().getProperties().setProperty( entry.getKey(), entry.getValue() );
                         }
                     }
                 }
             }
-            logger.info ("Iterating for explicit overrides...");
+            LOGGER.info ("Iterating for explicit overrides...");
             for ( final Map.Entry<String, String> entry : explicitVersionPropertyUpdateMap.entrySet() )
             {
                 PropertiesUtils.PropertyUpdate found = PropertiesUtils.updateProperties( session, result, true, entry.getKey(), entry.getValue() );
@@ -208,12 +208,12 @@ public class DependencyManipulator implements Manipulator
                     // Problem in this scenario is that we know we have a property update map but we have not found a
                     // property to update. Its possible this property has been inherited from a parent. Override in the
                     // top pom for safety.
-                    logger.info( "Unable to find a property for {} to update for explicit overrides", entry.getKey());
+                    LOGGER.info( "Unable to find a property for {} to update for explicit overrides", entry.getKey());
                     for ( final Project p : result )
                     {
                         if ( p.isInheritanceRoot() )
                         {
-                            logger.info( "Adding property {} with {} ", entry.getKey(), entry.getValue() );
+                            LOGGER.info( "Adding property {} with {} ", entry.getKey(), entry.getValue() );
                             p.getModel().getProperties().setProperty( entry.getKey(), entry.getValue() );
                         }
                     }
@@ -243,11 +243,11 @@ public class DependencyManipulator implements Manipulator
             moduleOverrides = applyModuleVersionOverrides( projectGA,
                                                            state.getDependencyExclusions(),
                                                            moduleOverrides, explicitOverrides );
-            logger.debug( "Module overrides are:\n{}", moduleOverrides );
+            LOGGER.debug( "Module overrides are:\n{}", moduleOverrides );
         }
         catch ( InvalidRefException e )
         {
-            logger.error( "Invalid module exclusion override {} : {} ", moduleOverrides, explicitOverrides );
+            LOGGER.error( "Invalid module exclusion override {} : {} ", moduleOverrides, explicitOverrides );
             throw e;
         }
 
@@ -275,7 +275,7 @@ public class DependencyManipulator implements Manipulator
                                 }
                                 else
                                 {
-                                    logger.warn( "Parent reference {} replacement: {} of original version: {} violates the strict version-alignment rule!",
+                                    LOGGER.warn( "Parent reference {} replacement: {} of original version: {} violates the strict version-alignment rule!",
                                                  ga( project.getParent() ), newValue, oldValue );
                                     // Ignore the dependency override. As found has been set to true it won't inject
                                     // a new property either.
@@ -284,7 +284,7 @@ public class DependencyManipulator implements Manipulator
                             }
                         }
 
-                        logger.debug( " Modifying parent reference from {} to {} for {} ",
+                        LOGGER.debug( " Modifying parent reference from {} to {} for {} ",
                                       model.getParent().getVersion(), newValue, ga( project.getParent() ) );
                         model.getParent().setVersion( newValue );
                         break;
@@ -311,13 +311,13 @@ public class DependencyManipulator implements Manipulator
                 {
                     dependencyManagement = new DependencyManagement();
                     model.setDependencyManagement( dependencyManagement );
-                    logger.debug( "Added <DependencyManagement/> for current project" );
+                    LOGGER.debug( "Added <DependencyManagement/> for current project" );
                 }
 
                 // Apply overrides to project dependency management
                 final List<Dependency> dependencies = dependencyManagement.getDependencies();
 
-                logger.debug( "Applying overrides to managed dependencies for top-pom: {}", projectGA );
+                LOGGER.debug( "Applying overrides to managed dependencies for top-pom: {}", projectGA );
 
                 final Map<ArtifactRef, String> nonMatchingVersionOverrides =
                                 applyOverrides( session, dependencies, moduleOverrides );
@@ -350,19 +350,19 @@ public class DependencyManipulator implements Manipulator
                         newDependency.setVersion( artifactVersion );
 
                         extraDeps.add( newDependency );
-                        logger.debug( "New entry added to <DependencyManagement/> - {} : {} ", var, artifactVersion );
+                        LOGGER.debug( "New entry added to <DependencyManagement/> - {} : {} ", var, artifactVersion );
                     }
 
                     dependencyManagement.getDependencies().addAll( 0, extraDeps );
                 }
                 else
                 {
-                    logger.debug( "Non-matching dependencies ignored." );
+                    LOGGER.debug( "Non-matching dependencies ignored." );
                 }
             }
             else
             {
-                logger.debug( "NOT applying overrides to managed dependencies for top-pom: {}", projectGA );
+                LOGGER.debug( "NOT applying overrides to managed dependencies for top-pom: {}", projectGA );
             }
         }
         else
@@ -371,20 +371,20 @@ public class DependencyManipulator implements Manipulator
             final DependencyManagement dependencyManagement = model.getDependencyManagement();
             if ( session.getState( DependencyState.class ).getOverrideDependencies() && dependencyManagement != null )
             {
-                logger.debug( "Applying overrides to managed dependencies for: {}", projectGA );
+                LOGGER.debug( "Applying overrides to managed dependencies for: {}", projectGA );
                 applyOverrides( session, dependencyManagement.getDependencies(), moduleOverrides );
                 applyExplicitOverrides( explicitVersionPropertyUpdateMap, explicitOverrides,
                                         dependencyManagement.getDependencies() );
             }
             else
             {
-                logger.debug( "NOT applying overrides to managed dependencies for: {}", projectGA );
+                LOGGER.debug( "NOT applying overrides to managed dependencies for: {}", projectGA );
             }
         }
 
         if ( session.getState( DependencyState.class ).getOverrideDependencies() )
         {
-            logger.debug( "Applying overrides to concrete dependencies for: {}", projectGA );
+            LOGGER.debug( "Applying overrides to concrete dependencies for: {}", projectGA );
             // Apply overrides to project direct dependencies
             final List<Dependency> projectDependencies = model.getDependencies();
             applyOverrides( session, projectDependencies, moduleOverrides );
@@ -410,7 +410,7 @@ public class DependencyManipulator implements Manipulator
         }
         else
         {
-            logger.debug( "NOT applying overrides to concrete dependencies for: {}", projectGA );
+            LOGGER.debug( "NOT applying overrides to concrete dependencies for: {}", projectGA );
         }
     }
 
@@ -442,24 +442,24 @@ public class DependencyManipulator implements Manipulator
                 {
                     if ( isEmpty( oldVersion ) )
                     {
-                        logger.warn( "Unable to force align as no existing version field to update for "
+                        LOGGER.warn( "Unable to force align as no existing version field to update for "
                                                      + groupIdArtifactId + "; ignoring" );
                     }
                     else
                     {
-                        logger.warn( "Unable to force align as override version is empty for " + groupIdArtifactId
+                        LOGGER.warn( "Unable to force align as override version is empty for " + groupIdArtifactId
                                                      + "; ignoring" );
                     }
                 }
                 else
                 {
-                    logger.info( "Explicit overrides : force aligning {} to {}.", groupIdArtifactId, overrideVersion );
+                    LOGGER.info( "Explicit overrides : force aligning {} to {}.", groupIdArtifactId, overrideVersion );
 
                     if ( ! PropertiesUtils.cacheProperty( versionPropertyUpdateMap, oldVersion, overrideVersion, dependency, true ))
                     {
                         if ( oldVersion.contains( "${" ))
                         {
-                            logger.warn( "Overriding version with {} when old version contained a property {} ", overrideVersion, oldVersion );
+                            LOGGER.warn( "Overriding version with {} when old version contained a property {} ", overrideVersion, oldVersion );
                             // TODO: Should this throw an exception?
                         }
                         // Not checking strict version alignment here as explicit overrides take priority.
@@ -517,11 +517,11 @@ public class DependencyManipulator implements Manipulator
 
                     if ( isEmpty( overrideVersion ) )
                     {
-                        logger.warn( "Unable to align with an empty override version for " + groupIdArtifactId + "; ignoring" );
+                        LOGGER.warn( "Unable to align with an empty override version for " + groupIdArtifactId + "; ignoring" );
                     }
                     else if ( isEmpty( oldVersion ) )
                     {
-                        logger.debug( "Dependency is a managed version for " + groupIdArtifactId + "; ignoring" );
+                        LOGGER.debug( "Dependency is a managed version for " + groupIdArtifactId + "; ignoring" );
                     }
                     // If we're doing strict matching with properties, then the original parts should match.
                     // i.e. assuming original resolved value is 1.2 and potential new value is 1.2.rebuild-1
@@ -535,7 +535,7 @@ public class DependencyManipulator implements Manipulator
                     else if ( strict && oldVersion.contains( "$" ) &&
                                     ! PropertiesUtils.checkStrictValue( session, resolvedValue, overrideVersion) )
                     {
-                        logger.debug ("Original fully resolved version {} of {} does not match override version {} -> {} so ignoring",
+                        LOGGER.debug ("Original fully resolved version {} of {} does not match override version {} -> {} so ignoring",
                                       resolvedValue, dependency, entry.getKey(), overrideVersion);
                         if ( state.getFailOnStrictViolation() )
                         {
@@ -545,7 +545,7 @@ public class DependencyManipulator implements Manipulator
                         }
                         else
                         {
-                            logger.warn( "Replacing original property version {} with new version {} for {} violates the strict version-alignment rule!",
+                            LOGGER.warn( "Replacing original property version {} with new version {} for {} violates the strict version-alignment rule!",
                                          resolvedValue, overrideVersion, dependency.getVersion() );
                         }
                     }
@@ -555,7 +555,7 @@ public class DependencyManipulator implements Manipulator
                         {
                             if ( oldVersion.equals( "${project.version}" ) )
                             {
-                                logger.debug( "For dependency {} ; version is built in {} so skipping inlining {}", groupIdArtifactId, oldVersion,
+                                LOGGER.debug( "For dependency {} ; version is built in {} so skipping inlining {}", groupIdArtifactId, oldVersion,
                                               overrideVersion );
                             }
                             else if ( strict && ! PropertiesUtils.checkStrictValue( session, resolvedValue, overrideVersion) )
@@ -568,19 +568,19 @@ public class DependencyManipulator implements Manipulator
                                 }
                                 else
                                 {
-                                    logger.warn( "Replacing original version {} in dependency {} with new version {} violates the strict version-alignment rule!",
+                                    LOGGER.warn( "Replacing original version {} in dependency {} with new version {} violates the strict version-alignment rule!",
                                                  oldVersion, groupIdArtifactId, overrideVersion );
                                 }
                             }
                             else
                             {
-                                logger.debug( "Altered dependency {} {} -> {}", groupIdArtifactId, oldVersion,
+                                LOGGER.debug( "Altered dependency {} {} -> {}", groupIdArtifactId, oldVersion,
                                               overrideVersion );
 
                                 if ( oldVersion.contains( "${" ) )
                                 {
                                     String appendValue = StringUtils.removeStart( overrideVersion, resolvedValue );
-                                    logger.debug ( "Resolved value is {} and appended is {} ", resolvedValue, appendValue );
+                                    LOGGER.debug ( "Resolved value is {} and appended is {} ", resolvedValue, appendValue );
 
                                     // In this case the previous value couldn't be cached even though it contained a property
                                     // as it was either multiple properties or a property combined with a hardcoded value. Therefore
@@ -642,7 +642,7 @@ public class DependencyManipulator implements Manipulator
     {
         final Map<ArtifactRef, String> remainingOverrides = new LinkedHashMap<>( originalOverrides );
 
-        logger.debug( "Calculating module-specific version overrides. Starting with:\n  {}",
+        LOGGER.debug( "Calculating module-specific version overrides. Starting with:\n  {}",
                       join( remainingOverrides.entrySet(), "\n  " ) );
 
         // These modes correspond to two different kinds of passes over the available override properties:
@@ -655,16 +655,16 @@ public class DependencyManipulator implements Manipulator
             {
                 final String currentValue = moduleOverrides.get( currentKey );
 
-                logger.debug( "Processing key {} for override with value {}", currentKey, currentValue );
+                LOGGER.debug( "Processing key {} for override with value {}", currentKey, currentValue );
 
                 if ( !currentKey.contains( "@" ) )
                 {
-                    logger.debug( "Not an override. Skip." );
+                    LOGGER.debug( "Not an override. Skip." );
                     continue;
                 }
 
                 final boolean isWildcard = currentKey.endsWith( "@*" );
-                logger.debug( "Is wildcard? {}", isWildcard );
+                LOGGER.debug( "Is wildcard? {}", isWildcard );
 
                 // process module-specific overrides (first)
                 if ( !aWildcardMode )
@@ -672,7 +672,7 @@ public class DependencyManipulator implements Manipulator
                     // skip wildcard overrides in this mode
                     if ( isWildcard )
                     {
-                        logger.debug( "Not currently in wildcard mode. Skip." );
+                        LOGGER.debug( "Not currently in wildcard mode. Skip." );
                         continue;
                     }
 
@@ -684,7 +684,7 @@ public class DependencyManipulator implements Manipulator
                     final String artifactGA = artifactAndModule[0];
                     final String moduleGA = artifactAndModule[1];
 
-                    logger.debug( "For artifact override: {}, comparing parsed module: {} to current project: {}",
+                    LOGGER.debug( "For artifact override: {}, comparing parsed module: {} to current project: {}",
                                   artifactGA, moduleGA, projectGA );
 
                     if ( moduleGA.equals( projectGA ) )
@@ -692,13 +692,13 @@ public class DependencyManipulator implements Manipulator
                         if ( currentValue != null && !currentValue.isEmpty() )
                         {
                             explicitOverrides.put( SimpleProjectRef.parse( artifactGA ), currentValue );
-                            logger.debug( "Overriding module dependency for {} with {} : {}", moduleGA, artifactGA,
+                            LOGGER.debug( "Overriding module dependency for {} with {} : {}", moduleGA, artifactGA,
                                           currentValue );
                         }
                         else
                         {
                             removeGA( remainingOverrides, SimpleProjectRef.parse( artifactGA ) );
-                            logger.debug( "Ignoring module dependency override for {} " + moduleGA );
+                            LOGGER.debug( "Ignoring module dependency override for {} " + moduleGA );
                         }
                     }
                 }
@@ -708,17 +708,17 @@ public class DependencyManipulator implements Manipulator
                     // skip module-specific overrides in this mode
                     if ( !isWildcard )
                     {
-                        logger.debug( "Currently in wildcard mode. Skip." );
+                        LOGGER.debug( "Currently in wildcard mode. Skip." );
                         continue;
                     }
 
                     final String artifactGA = currentKey.substring( 0, currentKey.length() - 2 );
-                    logger.debug( "For artifact override: {}, checking if current overrides already contain a module-specific version.",
+                    LOGGER.debug( "For artifact override: {}, checking if current overrides already contain a module-specific version.",
                                   artifactGA );
 
                     if ( explicitOverrides.containsKey( SimpleProjectRef.parse( artifactGA ) ) )
                     {
-                        logger.debug( "For artifact override: {}, current overrides already contain a module-specific version. Skip.",
+                        LOGGER.debug( "For artifact override: {}, current overrides already contain a module-specific version. Skip.",
                                       artifactGA );
                         continue;
                     }
@@ -726,7 +726,7 @@ public class DependencyManipulator implements Manipulator
                     // I think this is only used for e.g. dependencyExclusion.groupId:artifactId@*=<explicitVersion>
                     if ( currentValue != null && !currentValue.isEmpty() )
                     {
-                        logger.debug( "Overriding module dependency for {} with {} : {}", projectGA, artifactGA,
+                        LOGGER.debug( "Overriding module dependency for {} with {} : {}", projectGA, artifactGA,
                                       currentValue );
                         explicitOverrides.put( SimpleProjectRef.parse( artifactGA ), currentValue );
                     }
@@ -743,7 +743,7 @@ public class DependencyManipulator implements Manipulator
                                 final ArtifactRef pr = it.next();
                                 if ( artifactGAPr.getGroupId().equals( pr.getGroupId() ) )
                                 {
-                                    logger.debug( "Removing artifactGA " + pr + " from overrides" );
+                                    LOGGER.debug( "Removing artifactGA " + pr + " from overrides" );
                                     it.remove();
                                 }
                             }
@@ -751,9 +751,9 @@ public class DependencyManipulator implements Manipulator
                         else
                         {
                             removeGA( remainingOverrides, SimpleProjectRef.parse( artifactGA ) );
-                            logger.debug( "Removing artifactGA " + artifactGA + " from overrides" );
+                            LOGGER.debug( "Removing artifactGA " + artifactGA + " from overrides" );
                         }
-                        logger.debug( "Ignoring module dependency override for {} " + projectGA );
+                        LOGGER.debug( "Ignoring module dependency override for {} " + projectGA );
                     }
                 }
             }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/DistributionEnforcingManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/DistributionEnforcingManipulator.java
@@ -91,7 +91,7 @@ public class DistributionEnforcingManipulator
 
     private static final String DEFAULT_INSTALL_EXEC = "default-install";
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( DistributionEnforcingManipulator.class );
 
     @Requirement
     private GalleyAPIWrapper galleyWrapper;
@@ -141,7 +141,7 @@ public class DistributionEnforcingManipulator
         final DistributionEnforcingState state = session.getState( DistributionEnforcingState.class );
         if ( state == null || !state.isEnabled() )
         {
-            logger.debug( "Distribution skip-flag enforcement is disabled." );
+            LOGGER.debug( "Distribution skip-flag enforcement is disabled." );
             return Collections.emptySet();
         }
 
@@ -162,11 +162,11 @@ public class DistributionEnforcingManipulator
 
             if ( mode == EnforcingMode.none )
             {
-                logger.info( "Install/Deploy skip-flag enforcement is disabled for: {}.", ga );
+                LOGGER.info( "Install/Deploy skip-flag enforcement is disabled for: {}.", ga );
                 continue;
             }
 
-            logger.info( "Applying skip-flag enforcement mode of: " + mode + " to: " + ga );
+            LOGGER.info( "Applying skip-flag enforcement mode of: " + mode + " to: " + ga );
 
             final Model model = project.getModel();
 
@@ -235,7 +235,7 @@ public class DistributionEnforcingManipulator
 
         if ( skipSetting == null )
         {
-            logger.warn( "No setting to enforce for skip-flag! Aborting enforcement..." );
+            LOGGER.warn( "No setting to enforce for skip-flag! Aborting enforcement..." );
             return null;
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/GroovyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/GroovyManipulator.java
@@ -47,7 +47,7 @@ import java.util.Set;
 public class GroovyManipulator
     implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( GroovyManipulator.class );
 
     @Requirement
     protected ModelIO modelBuilder;
@@ -83,7 +83,7 @@ public class GroovyManipulator
         final GroovyState state = session.getState( GroovyState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -92,7 +92,7 @@ public class GroovyManipulator
 
         for (ArtifactRef ar : scripts)
         {
-            logger.info ("Attempting to read GAV {} with classifier {} and type {} ",
+            LOGGER.info ("Attempting to read GAV {} with classifier {} and type {} ",
                          ar.asProjectVersionRef(), ar.getClassifier(), ar.getType());
 
             final File groovyScript = modelBuilder.resolveRawFile( ar );
@@ -104,7 +104,7 @@ public class GroovyManipulator
             {
                 if ( project.isExecutionRoot() )
                 {
-                    logger.info ("Executing {} on {}", groovyScript, project);
+                    LOGGER.info ("Executing {} on {}", groovyScript, project);
 
                     try
                     {
@@ -116,11 +116,11 @@ public class GroovyManipulator
                     {
                         try
                         {
-                            logger.debug ( "Failure when injecting into script {} ", FileUtils.readFileToString( groovyScript ) );
+                            LOGGER.debug ( "Failure when injecting into script {} ", FileUtils.readFileToString( groovyScript ) );
                         }
                         catch ( IOException e1 )
                         {
-                            logger.debug ("Unable to read script file {} for debugging! {} ", groovyScript, e1);
+                            LOGGER.debug ("Unable to read script file {} for debugging! {} ", groovyScript, e1);
                         }
                         throw new ManipulationException( "Unable to inject values into base script", e );
                     }
@@ -128,11 +128,11 @@ public class GroovyManipulator
                     {
                         try
                         {
-                            logger.debug ( "Failure when parsing script {} ", FileUtils.readFileToString( groovyScript ) );
+                            LOGGER.debug ( "Failure when parsing script {} ", FileUtils.readFileToString( groovyScript ) );
                         }
                         catch ( IOException e1 )
                         {
-                            logger.debug ("Unable to read script file {} for debugging! {} ", groovyScript, e1);
+                            LOGGER.debug ("Unable to read script file {} for debugging! {} ", groovyScript, e1);
                         }
                         throw new ManipulationException( "Unable to parse script", e );
                     }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/JSONManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/JSONManipulator.java
@@ -44,7 +44,7 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
 public class JSONManipulator
     implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( JSONManipulator.class );
 
     @Requirement
     private JSONIO jsonIO;
@@ -78,7 +78,7 @@ public class JSONManipulator
         final JSONState state = session.getState( JSONState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -93,7 +93,7 @@ public class JSONManipulator
                 {
                     File target = new File( project.getPom().getParentFile(), operation.getFile() );
 
-                    logger.info( "Attempting to start JSON update to file {} with xpath {} and replacement '{}' ",
+                    LOGGER.info( "Attempting to start JSON update to file {} with xpath {} and replacement '{}' ",
                                  target, operation.getXPath(), operation.getUpdate() );
 
                     internalApplyChanges (target, operation);
@@ -115,7 +115,7 @@ public class JSONManipulator
         {
             if ( !target.exists() )
             {
-                logger.error( "Unable to locate JSON file {} ", target );
+                LOGGER.error( "Unable to locate JSON file {} ", target );
                 throw new ManipulationException( "Unable to locate JSON file " + target );
             }
 
@@ -124,7 +124,7 @@ public class JSONManipulator
             List o = dc.read( operation.getXPath() );
             if ( o.size() == 0 )
             {
-                logger.error( "XPath {} did not find any expressions within {} ", operation.getXPath(),
+                LOGGER.error( "XPath {} did not find any expressions within {} ", operation.getXPath(),
                               operation.getFile() );
                 throw new ManipulationException( "XPath did not resolve to a valid value" );
             }
@@ -132,13 +132,13 @@ public class JSONManipulator
             if ( isEmpty( operation.getUpdate() ) )
             {
                 // Delete
-                logger.info( "Deleting {} on {}", operation.getXPath(), dc.toString() );
+                LOGGER.info( "Deleting {} on {}", operation.getXPath(), dc.toString() );
                 dc.delete( operation.getXPath() );
             }
             else
             {
                 // Update
-                logger.info( "Updating {} on {}", operation.getXPath(), dc.toString() );
+                LOGGER.info( "Updating {} on {}", operation.getXPath(), dc.toString() );
                 dc.set( operation.getXPath(), operation.getUpdate() );
             }
 
@@ -146,7 +146,7 @@ public class JSONManipulator
         }
         catch ( JsonPathException e )
         {
-            logger.error( "Caught JSON exception processing file {}, document context {} ", target, dc, e );
+            LOGGER.error( "Caught JSON exception processing file {}, document context {} ", target, dc, e );
             throw new ManipulationException( "Caught JsonPath", e );
         }
     }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/PluginManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/PluginManipulator.java
@@ -85,7 +85,7 @@ public class PluginManipulator
         }
     }
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( PluginManipulator.class );
 
     @Requirement
     private ModelIO effectiveModelBuilder;
@@ -122,7 +122,7 @@ public class PluginManipulator
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -151,7 +151,7 @@ public class PluginManipulator
         // If we've changed something now update any old properties with the new values.
         if (!changed.isEmpty())
         {
-            logger.info( "Iterating for standard overrides..." );
+            LOGGER.info( "Iterating for standard overrides..." );
             for ( final String key : state.getVersionPropertyOverrides().keySet() )
             {
                 // Ignore strict alignment for plugins ; if we're attempting to use a differing plugin
@@ -163,12 +163,12 @@ public class PluginManipulator
                     // Problem in this scenario is that we know we have a property update map but we have not found a
                     // property to update. Its possible this property has been inherited from a parent. Override in the
                     // top pom for safety.
-                    logger.info( "Unable to find a property for {} to update", key );
+                    LOGGER.info( "Unable to find a property for {} to update", key );
                     for ( final Project p : changed )
                     {
                         if ( p.isInheritanceRoot() )
                         {
-                            logger.info( "Adding property {} with {} ", key, state.getVersionPropertyOverride( key ) );
+                            LOGGER.info( "Adding property {} with {} ", key, state.getVersionPropertyOverride( key ) );
                             p.getModel().getProperties().setProperty( key, state.getVersionPropertyOverride( key ) );
                         }
                     }
@@ -216,7 +216,7 @@ public class PluginManipulator
                         PluginType type, final Map<ProjectRef, Plugin> override )
         throws ManipulationException
     {
-        logger.info( "Applying plugin changes for {} to: {} ", type, ga( project ) );
+        LOGGER.info( "Applying plugin changes for {} to: {} ", type, ga( project ) );
 
         PluginState state = session.getState( PluginState.class );
 
@@ -229,7 +229,7 @@ public class PluginManipulator
             {
                 build = new Build();
                 model.setBuild( build );
-                logger.info( "Created new Build for model " + model.getId() );
+                LOGGER.info( "Created new Build for model " + model.getId() );
             }
 
             PluginManagement pluginManagement = model.getBuild()
@@ -240,7 +240,7 @@ public class PluginManipulator
                 pluginManagement = new PluginManagement();
                 model.getBuild()
                      .setPluginManagement( pluginManagement );
-                logger.info( "Created new Plugin Management for model " + model.getId() );
+                LOGGER.info( "Created new Plugin Management for model " + model.getId() );
             }
 
             // Override plugin management versions
@@ -280,7 +280,7 @@ public class PluginManipulator
         for ( final Plugin override : pluginVersionOverrides.values())
         {
             final int index = plugins.indexOf( override );
-            logger.debug( "Plugin override {} with index {} with remotePluginType {} / localPluginType {}", override, index, remotePluginType, localPluginType );
+            LOGGER.debug( "Plugin override {} with index {} with remotePluginType {} / localPluginType {}", override, index, remotePluginType, localPluginType );
 
             if ( index != -1 )
             {
@@ -289,15 +289,15 @@ public class PluginManipulator
 
                 if ( override.getConfiguration() != null)
                 {
-                    logger.debug ("Injecting plugin configuration" + override.getConfiguration());
+                    LOGGER.debug ("Injecting plugin configuration" + override.getConfiguration());
                     if (localPluginType == PluginType.LocalPM && plugin.getConfiguration() == null)
                     {
                         plugin.setConfiguration( override.getConfiguration() );
-                        logger.debug( "Altered plugin configuration: " + groupIdArtifactId + "=" + plugin.getConfiguration());
+                        LOGGER.debug( "Altered plugin configuration: " + groupIdArtifactId + "=" + plugin.getConfiguration());
                     }
                     else if (localPluginType == PluginType.LocalPM && plugin.getConfiguration() != null)
                     {
-                        logger.debug( "Existing plugin configuration: " + plugin.getConfiguration());
+                        LOGGER.debug( "Existing plugin configuration: " + plugin.getConfiguration());
 
                         if ( ! (plugin.getConfiguration() instanceof Xpp3Dom) || ! (override.getConfiguration() instanceof Xpp3Dom))
                         {
@@ -315,12 +315,12 @@ public class PluginManipulator
                             plugin.setConfiguration ( Xpp3DomUtils.mergeXpp3Dom
                                                       ((Xpp3Dom)plugin.getConfiguration(), (Xpp3Dom)override.getConfiguration() ) );
                         }
-                        logger.debug( "Altered plugin configuration: " + groupIdArtifactId + "=" + plugin.getConfiguration());
+                        LOGGER.debug( "Altered plugin configuration: " + groupIdArtifactId + "=" + plugin.getConfiguration());
                     }
                 }
                 else
                 {
-                    logger.debug ("No remote configuration to inject from " + override.toString());
+                    LOGGER.debug ("No remote configuration to inject from " + override.toString());
                 }
 
                 if (override.getExecutions() != null)
@@ -332,11 +332,11 @@ public class PluginManipulator
                     {
                         if (originalExecutions.containsKey( pe.getId() ) )
                         {
-                            logger.warn ("Unable to inject execution " + pe.getId() + " as it clashes with an existing execution");
+                            LOGGER.warn ("Unable to inject execution " + pe.getId() + " as it clashes with an existing execution");
                         }
                         else
                         {
-                            logger.debug ("Injecting execution {} ", pe);
+                            LOGGER.debug ("Injecting execution {} ", pe);
                             plugin.getExecutions().add (pe);
                         }
                     }
@@ -344,7 +344,7 @@ public class PluginManipulator
 
                 if (!override.getDependencies().isEmpty())
                 {
-                    logger.debug( "Checking original plugin dependencies versus override" );
+                    LOGGER.debug( "Checking original plugin dependencies versus override" );
                     // First, remove any Dependency from the original Plugin if the GA exists in the override.
                     Iterator<Dependency> originalIt = plugin.getDependencies().iterator();
                     while (originalIt.hasNext())
@@ -357,14 +357,14 @@ public class PluginManipulator
                             if (originalD.getGroupId().equals( newD.getGroupId() ) &&
                                 originalD.getArtifactId().equals( newD.getArtifactId() ) )
                             {
-                                logger.debug( "Removing original dependency {} in favour of {} ", originalD, newD );
+                                LOGGER.debug( "Removing original dependency {} in favour of {} ", originalD, newD );
                                 originalIt.remove();
                                 break;
                             }
                         }
                     }
                     // Now merge them together.
-                    logger.debug( "Adding in plugin dependencies {}", override.getDependencies() );
+                    LOGGER.debug( "Adding in plugin dependencies {}", override.getDependencies() );
                     plugin.getDependencies().addAll( override.getDependencies() );
                 }
 
@@ -377,7 +377,7 @@ public class PluginManipulator
                     {
                         if ( oldVersion != null && oldVersion.equals( "${project.version}" ) )
                         {
-                            logger.debug( "For plugin {} ; version is built in {} so skipping inlining {}", plugin,
+                            LOGGER.debug( "For plugin {} ; version is built in {} so skipping inlining {}", plugin,
                                           oldVersion, override.getVersion() );
                         }
                         else if ( oldVersion != null && oldVersion.contains( "${" ) )
@@ -387,7 +387,7 @@ public class PluginManipulator
                         else
                         {
                             plugin.setVersion( override.getVersion() );
-                            logger.info( "Altered plugin version: " + groupIdArtifactId + "=" + override.getVersion() );
+                            LOGGER.info( "Altered plugin version: " + groupIdArtifactId + "=" + override.getVersion() );
                         }
                     }
                 }
@@ -400,7 +400,7 @@ public class PluginManipulator
                             ( override.getConfiguration() != null || override.getExecutions().size() > 0 ) )
             {
                 plugins.add( override );
-                logger.info( "Added plugin version: " + override.getKey() + "=" + override.getVersion());
+                LOGGER.info( "Added plugin version: " + override.getKey() + "=" + override.getVersion());
             }
             // If the plugin in <plugins> doesn't exist but has a configuration section in the remote inject it so we
             // get the correct config.
@@ -410,7 +410,7 @@ public class PluginManipulator
                             ( override.getConfiguration() != null || override.getExecutions().size() > 0 ) )
             {
                 plugins.add( override );
-                logger.info( "For non-pluginMgmt, added plugin version : " + override.getKey() + "=" + override.getVersion());
+                LOGGER.info( "For non-pluginMgmt, added plugin version : " + override.getKey() + "=" + override.getVersion());
             }
         }
     }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/PluginRemovalManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/PluginRemovalManipulator.java
@@ -47,7 +47,7 @@ import static org.commonjava.maven.ext.manip.util.IdUtils.ga;
 public class PluginRemovalManipulator
         implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( PluginRemovalManipulator.class );
 
     /**
      * Initialize the {@link PluginState} state holder in the {@link ManipulationSession}. This state holder detects
@@ -81,7 +81,7 @@ public class PluginRemovalManipulator
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -104,7 +104,7 @@ public class PluginRemovalManipulator
     {
         final PluginRemovalState state = session.getState( PluginRemovalState.class );
 
-        logger.info( "Applying plugin changes to: " + ga( project ) );
+        LOGGER.info( "Applying plugin changes to: " + ga( project ) );
 
         boolean result = false;
         List<ProjectRef> pluginsToRemove = state.getPluginRemoval();
@@ -134,7 +134,7 @@ public class PluginRemovalManipulator
                 Plugin p = it.next();
                 if ( pluginsToRemove.contains( SimpleProjectRef.parse( p.getKey() ) ) )
                 {
-                    logger.debug( "Removing {} ", p.toString() );
+                    LOGGER.debug( "Removing {} ", p.toString() );
                     it.remove();
                     result = true;
                 }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProfileInjectionManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProfileInjectionManipulator.java
@@ -47,7 +47,7 @@ import static org.commonjava.maven.ext.manip.util.IdUtils.ga;
 public class ProfileInjectionManipulator
     implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ProfileInjectionManipulator.class );
 
     @Requirement
     private ModelIO modelBuilder;
@@ -83,7 +83,7 @@ public class ProfileInjectionManipulator
         final ProfileInjectionState state = session.getState( ProfileInjectionState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -96,7 +96,7 @@ public class ProfileInjectionManipulator
         {
             if ( project.isInheritanceRoot() )
             {
-                logger.info( "Applying changes to: {} ", ga( project ) );
+                LOGGER.info( "Applying changes to: {} ", ga( project ) );
                 final Model model = project.getModel();
                 final List<Profile> profiles = model.getProfiles();
 
@@ -134,7 +134,7 @@ public class ProfileInjectionManipulator
             if ( profile.getId()
                         .equals( p.getId() ) )
             {
-                logger.debug( "Removing local profile {} ", p );
+                LOGGER.debug( "Removing local profile {} ", p );
                 i.remove();
                 // Don't break out of the loop so we can check for active profiles
             }
@@ -144,7 +144,7 @@ public class ProfileInjectionManipulator
             // of activeByDefault. Therefore replace the activation.
             if (p.getActivation() != null && p.getActivation().isActiveByDefault())
             {
-                logger.warn( "Profile {} is activeByDefault", p );
+                LOGGER.warn( "Profile {} is activeByDefault", p );
 
                 final Activation replacement = new Activation();
                 final ActivationProperty replacementProp = new ActivationProperty();
@@ -155,7 +155,7 @@ public class ProfileInjectionManipulator
             }
         }
 
-        logger.debug( "Adding profile {}", profile );
+        LOGGER.debug( "Adding profile {}", profile );
         profiles.add( profile );
     }
 

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProfileRemovalManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProfileRemovalManipulator.java
@@ -42,7 +42,7 @@ import static org.commonjava.maven.ext.manip.util.IdUtils.ga;
 public class ProfileRemovalManipulator
     implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ProfileRemovalManipulator.class );
 
     /**
      * No prescanning required for Profile removal.
@@ -75,7 +75,7 @@ public class ProfileRemovalManipulator
         final ProfileRemovalState state = session.getState( ProfileRemovalState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -85,7 +85,7 @@ public class ProfileRemovalManipulator
         for ( final Project project : projects )
         {
             final String ga = ga( project );
-            logger.info( "Applying changes to: " + ga );
+            LOGGER.info( "Applying changes to: " + ga );
 
             final Model model = project.getModel();
             final List<Profile> profiles = model.getProfiles();
@@ -99,7 +99,7 @@ public class ProfileRemovalManipulator
                 {
                     if (p.getId().equals( id ))
                     {
-                        logger.debug ("Removing profile {}", p.getId());
+                        LOGGER.debug ("Removing profile {}", p.getId());
                         i.remove();
                         break;
                     }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProjectSourcesInjectingManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProjectSourcesInjectingManipulator.java
@@ -72,7 +72,7 @@ public class ProjectSourcesInjectingManipulator
 
     private static final String INITIALIZE_PHASE = "initialize";
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ProjectSourcesInjectingManipulator.class );
 
     @Override
     public void init( final ManipulationSession session )
@@ -106,7 +106,7 @@ public class ProjectSourcesInjectingManipulator
             {
                 if ( project.isExecutionRoot() )
                 {
-                    logger.info( "Examining {} to apply sources/metadata plugins.", project );
+                    LOGGER.info( "Examining {} to apply sources/metadata plugins.", project );
 
                     final Model model = project.getModel();
                     Build build = model.getBuild();

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProjectVersionEnforcingManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProjectVersionEnforcingManipulator.java
@@ -48,7 +48,7 @@ public class ProjectVersionEnforcingManipulator
 
     private static final String PROJVER = "${project.version}";
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ProjectVersionEnforcingManipulator.class );
 
     /**
      * Sets the mode based on user properties and defaults.
@@ -81,7 +81,7 @@ public class ProjectVersionEnforcingManipulator
                         !session.anyStateEnabled( State.activeByDefault ) ||
                         state == null || !state.isEnabled() )
         {
-            logger.debug( "Project version enforcement is disabled." );
+            LOGGER.debug( "Project version enforcement is disabled." );
             return Collections.emptySet();
         }
 
@@ -117,7 +117,7 @@ public class ProjectVersionEnforcingManipulator
         }
         if (!changed.isEmpty())
         {
-            logger.warn( "Using ${project.version} in pom files may lead to unexpected errors with inheritance." );
+            LOGGER.warn( "Using ${project.version} in pom files may lead to unexpected errors with inheritance." );
         }
         return changed;
     }
@@ -131,7 +131,7 @@ public class ProjectVersionEnforcingManipulator
                 String newVersion =  project.getModel().getVersion() == null ?
                                 project.getModel().getParent ().getVersion () : project.getModel().getVersion ();
 
-                logger.debug( "Replacing project.version within {} for project {} with {}", d, project, newVersion);
+                LOGGER.debug( "Replacing project.version within {} for project {} with {}", d, project, newVersion);
 
                 d.setVersion( newVersion );
                 changed.add( project );

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProjectVersioningManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/ProjectVersioningManipulator.java
@@ -60,7 +60,7 @@ import static org.commonjava.maven.ext.manip.util.IdUtils.gav;
 public class ProjectVersioningManipulator
     implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ProjectVersioningManipulator.class );
 
     @Requirement
     private VersionCalculator calculator;
@@ -86,11 +86,11 @@ public class ProjectVersioningManipulator
         final VersioningState state = session.getState( VersioningState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( "Version Manipulator: Nothing to do!" );
+            LOGGER.debug( "Version Manipulator: Nothing to do!" );
             return;
         }
 
-        logger.info( "Version Manipulator: Calculating the necessary versioning changes." );
+        LOGGER.info( "Version Manipulator: Calculating the necessary versioning changes." );
         state.setVersionsByGAVMap( calculator.calculateVersioningChanges( projects, session ) );
     }
 
@@ -119,7 +119,7 @@ public class ProjectVersioningManipulator
 
         if ( !session.isEnabled() || state == null || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -128,7 +128,7 @@ public class ProjectVersioningManipulator
         for ( final Project project : projects )
         {
             final String ga = ga( project );
-            logger.info( "Applying changes to: " + ga );
+            LOGGER.info( "Applying changes to: " + ga );
             if ( applyVersioningChanges( session, projects, project, state ) )
             {
                 changed.add( project );
@@ -172,7 +172,7 @@ public class ProjectVersioningManipulator
             return false;
         }
 
-        logger.info( "Looking for applicable versioning changes in: " + gav( model ) );
+        LOGGER.info( "Looking for applicable versioning changes in: " + gav( model ) );
 
         String g = model.getGroupId();
         String v = model.getVersion();
@@ -200,12 +200,12 @@ public class ProjectVersioningManipulator
             if ( versionsByGAV.containsKey( parentGAV ) )
             {
                 final String newVersion = versionsByGAV.get( parentGAV );
-                logger.info( "Changed parent version to: " + newVersion + " in " + parent );
+                LOGGER.info( "Changed parent version to: " + newVersion + " in " + parent );
                 if (parentGAV.getVersionString().startsWith( "${" ))
                 {
                     if ( PropertiesUtils.updateProperties( session, new HashSet<>( projects ), false, extractPropertyName( parentGAV.getVersionString() ), newVersion ) == PropertiesUtils.PropertyUpdate.NOTFOUND )
                     {
-                        logger.error( "Unable to find property {} to update with version {}", parentGAV.getVersionString(), newVersion );
+                        LOGGER.error( "Unable to find property {} to update with version {}", parentGAV.getVersionString(), newVersion );
                     }
                 }
                 else
@@ -220,21 +220,21 @@ public class ProjectVersioningManipulator
         if ( model.getVersion() != null )
         {
             final String newVersion = versionsByGAV.get( gav );
-            logger.info( "Looking for new version: " + gav + " (found: " + newVersion + ")" );
+            LOGGER.info( "Looking for new version: " + gav + " (found: " + newVersion + ")" );
             if ( newVersion != null && model.getVersion() != null )
             {
                 if (gav.getVersionString().startsWith( "${" ))
                 {
                     if ( PropertiesUtils.updateProperties( session, new HashSet<>( projects ), false, extractPropertyName( gav.getVersionString() ), newVersion ) == PropertiesUtils.PropertyUpdate.NOTFOUND )
                     {
-                        logger.error( "Unable to find property {} to update with version {}", gav.getVersionString(), newVersion );
+                        LOGGER.error( "Unable to find property {} to update with version {}", gav.getVersionString(), newVersion );
                     }
                 }
                 else
                 {
                     model.setVersion( newVersion );
                 }
-                logger.info( "Changed main version in " + gav( model ) );
+                LOGGER.info( "Changed main version in " + gav( model ) );
                 changed = true;
             }
         }
@@ -244,7 +244,7 @@ public class ProjectVersioningManipulator
         else if ( changed == false && model.getVersion() == null && project.isInheritanceRoot())
         {
             final String newVersion = versionsByGAV.get( gav );
-            logger.info( "Looking to force inject new version for : " + gav + " (found: " + newVersion + ")" );
+            LOGGER.info( "Looking to force inject new version for : " + gav + " (found: " + newVersion + ")" );
             if (newVersion != null)
             {
                 model.setVersion( newVersion );
@@ -272,7 +272,7 @@ public class ProjectVersioningManipulator
                 {
                     if ( isEmpty (pi.interp( d.getVersion() )))
                     {
-                        logger.trace( "Skipping dependency " + d + " as empty version." );
+                        LOGGER.trace( "Skipping dependency " + d + " as empty version." );
                         continue;
                     }
                     try
@@ -287,20 +287,20 @@ public class ProjectVersioningManipulator
                             {
                                 if ( PropertiesUtils.updateProperties( session, new HashSet<>( projects ), false, extractPropertyName( d.getVersion() ), newVersion ) == PropertiesUtils.PropertyUpdate.NOTFOUND )
                                 {
-                                    logger.error( "Unable to find property {} to update with version {}", d.getVersion(), newVersion );
+                                    LOGGER.error( "Unable to find property {} to update with version {}", d.getVersion(), newVersion );
                                 }
                             }
                             else
                             {
                                 d.setVersion( newVersion );
                             }
-                            logger.info( "Changed managed: " + d + " in " + base + " to " + newVersion + " from " + gav.getVersionString() );
+                            LOGGER.info( "Changed managed: " + d + " in " + base + " to " + newVersion + " from " + gav.getVersionString() );
                             changed = true;
                         }
                     }
                     catch ( InvalidRefException ire)
                     {
-                        logger.debug( "Unable to change version for dependency {} due to {} ", d.toString(), ire );
+                        LOGGER.debug( "Unable to change version for dependency {} due to {} ", d.toString(), ire );
                     }
                 }
             }
@@ -313,7 +313,7 @@ public class ProjectVersioningManipulator
                     {
                         if ( isEmpty (pi.interp( d.getVersion() )))
                         {
-                            logger.trace( "Skipping dependency " + d + " as empty version." );
+                            LOGGER.trace( "Skipping dependency " + d + " as empty version." );
                             continue;
                         }
 
@@ -329,20 +329,20 @@ public class ProjectVersioningManipulator
                             {
                                 if ( PropertiesUtils.updateProperties( session, new HashSet<>( projects ), false, extractPropertyName( d.getVersion() ), newVersion ) == PropertiesUtils.PropertyUpdate.NOTFOUND )
                                 {
-                                    logger.error( "Unable to find property {} to update with version {}", d.getVersion(), newVersion );
+                                    LOGGER.error( "Unable to find property {} to update with version {}", d.getVersion(), newVersion );
                                 }
                             }
                             else
                             {
                                 d.setVersion( newVersion );
                             }
-                            logger.info( "Changed: " + d + " in " + base + " to " + newVersion + " from " + gav.getVersionString());
+                            LOGGER.info( "Changed: " + d + " in " + base + " to " + newVersion + " from " + gav.getVersionString());
                             changed = true;
                         }
                     }
                     catch ( InvalidRefException ire)
                     {
-                        logger.debug( "Unable to change version for dependency {} due to {} ", d.toString(), ire );
+                        LOGGER.debug( "Unable to change version for dependency {} due to {} ", d.toString(), ire );
                     }
                 }
             }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/PropertyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/PropertyManipulator.java
@@ -45,7 +45,7 @@ import static org.commonjava.maven.ext.manip.util.IdUtils.ga;
 public class PropertyManipulator
     implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( PropertyManipulator.class );
 
     @Requirement
     private ModelIO effectiveModelBuilder;
@@ -77,7 +77,7 @@ public class PropertyManipulator
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -93,7 +93,7 @@ public class PropertyManipulator
                 // Only inject the new properties at the top level.
                 if ( project.isInheritanceRoot() )
                 {
-                    logger.info( "Applying property changes to: " + ga( project ) + " with " + overrides );
+                    LOGGER.info( "Applying property changes to: " + ga( project ) + " with " + overrides );
 
                     model.getProperties().putAll( overrides );
 
@@ -113,7 +113,7 @@ public class PropertyManipulator
                         while (keys.hasNext())
                         {
                             final String matchingKey = keys.next();
-                            logger.info( "Overwriting property (" + matchingKey + " in: " + ga( project ) + " with value " + overrides.get( matchingKey ) );
+                            LOGGER.info( "Overwriting property (" + matchingKey + " in: " + ga( project ) + " with value " + overrides.get( matchingKey ) );
                             model.getProperties().put( matchingKey, overrides.get( matchingKey ) );
 
                             changed.add( project );

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/RESTManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/RESTManipulator.java
@@ -59,7 +59,7 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
 @Component( role = Manipulator.class, hint = "rest-manipulator" )
 public class RESTManipulator implements Manipulator
 {
-    private static final Logger logger = LoggerFactory.getLogger( RESTManipulator.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( RESTManipulator.class );
 
     @Override
     public void init( final ManipulationSession session )
@@ -81,7 +81,7 @@ public class RESTManipulator implements Manipulator
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return;
         }
 
@@ -105,7 +105,7 @@ public class RESTManipulator implements Manipulator
                 }
                 else
                 {
-                    logger.warn( "SNAPSHOT detected for REST call but preserve-snapshots is enabled." );
+                    LOGGER.warn( "SNAPSHOT detected for REST call but preserve-snapshots is enabled." );
                 }
             }
             newProjectKeys.add( newKey );
@@ -122,8 +122,8 @@ public class RESTManipulator implements Manipulator
         }
 
         // Call the REST to populate the result.
-        logger.debug ("Passing {} GAVs following into the REST client api {} ", restParam.size(), restParam);
-        logger.info ("Calling REST client...");
+        LOGGER.debug ("Passing {} GAVs following into the REST client api {} ", restParam.size(), restParam);
+        LOGGER.info ("Calling REST client...");
         long start = System.nanoTime();
         Map<ProjectVersionRef, String> restResult;
 
@@ -139,7 +139,7 @@ public class RESTManipulator implements Manipulator
         {
             printFinishTime( start );
         }
-        logger.debug ("REST Client returned {} ", restResult);
+        LOGGER.debug ("REST Client returned {} ", restResult);
 
         // Parse the rest result for the project GAs and store them in versioning state for use
         // there by incremental suffix calculation.
@@ -158,7 +158,7 @@ public class RESTManipulator implements Manipulator
                 versions.add( restResult.get( p ) );
             }
         }
-        logger.info ("Added the following ProjectRef:Version from REST call into VersionState {}", versionStates);
+        LOGGER.info ("Added the following ProjectRef:Version from REST call into VersionState {}", versionStates);
         vs.setRESTMetadata (versionStates);
 
         final DependencyState ds = session.getState( DependencyState.class );
@@ -172,7 +172,7 @@ public class RESTManipulator implements Manipulator
                 overrides.put( a, restResult.get( a.asProjectVersionRef()));
             }
         }
-        logger.debug( "Setting REST Overrides {} ", overrides );
+        LOGGER.debug( "Setting REST Overrides {} ", overrides );
         ds.setRemoteRESTOverrides( overrides );
     }
 
@@ -250,7 +250,7 @@ public class RESTManipulator implements Manipulator
                     }
                 }
             }
-            logger.debug ("Found {} active modules with {} active profiles.", activeModules, activeProfiles);
+            LOGGER.debug ("Found {} active modules with {} active profiles.", activeModules, activeProfiles);
         }
         else
         {
@@ -318,7 +318,7 @@ public class RESTManipulator implements Manipulator
 
             if ( excludeEmptyVersions && isEmpty( d.getVersion() ) )
             {
-                logger.trace( "Skipping dependency " + d + " as empty version." );
+                LOGGER.trace( "Skipping dependency " + d + " as empty version." );
             }
             else
             {
@@ -328,7 +328,7 @@ public class RESTManipulator implements Manipulator
                 if ( isEmpty ( version ) )
                 {
                     // Hack for non-managed versions to be stored in this set. Only used by CLI codepath
-                    logger.trace( "Version for " + d + " is empty." );
+                    LOGGER.trace( "Version for " + d + " is empty." );
                     version = "<unknown>";
                 }
 
@@ -349,7 +349,7 @@ public class RESTManipulator implements Manipulator
         long finish = System.nanoTime();
         long minutes = TimeUnit.NANOSECONDS.toMinutes( finish - start );
         long seconds = TimeUnit.NANOSECONDS.toSeconds( finish - start ) - ( minutes * 60 );
-        logger.info ( "REST client finished... (took {} min, {} sec, {} millisec)", minutes, seconds,
+        LOGGER.info ( "REST client finished... (took {} min, {} sec, {} millisec)", minutes, seconds,
                       (TimeUnit.NANOSECONDS.toMillis( finish - start ) - ( minutes * 60 * 1000 ) - ( seconds * 1000) ));
     }
 }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/RelocationManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/RelocationManipulator.java
@@ -49,7 +49,7 @@ import static org.commonjava.maven.ext.manip.util.IdUtils.ga;
 public class RelocationManipulator
         implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( RelocationManipulator.class );
 
     /**
      * Initialize the {@link PluginState} state holder in the {@link ManipulationSession}. This state holder detects
@@ -84,7 +84,7 @@ public class RelocationManipulator
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -109,7 +109,7 @@ public class RelocationManipulator
         final RelocationState state = session.getState( RelocationState.class );
         final WildcardMap<ProjectVersionRef> relocations = state.getDependencyRelocations();
 
-        logger.info( "Applying relocation changes to: " + ga( project ) );
+        LOGGER.info( "Applying relocation changes to: " + ga( project ) );
 
         DependencyManagement dependencyManagement = model.getDependencyManagement();
         if ( dependencyManagement != null )
@@ -143,7 +143,7 @@ public class RelocationManipulator
                 ProjectVersionRef pvr = relocations.get( d );
                 updateDependencyExclusion(session, pvr, d);
 
-                logger.info ("Replacing groupId {} by {} and artifactId {} with {}",
+                LOGGER.info ("Replacing groupId {} by {} and artifactId {} with {}",
                              d.getGroupId(), pvr.getGroupId(), d.getArtifactId(), pvr.getGroupId() );
 
                 if ( ! pvr.getArtifactId().equals( WildcardMap.WILDCARD ))
@@ -169,7 +169,7 @@ public class RelocationManipulator
 
         if (projectVersionRef.getVersionString().equals( WildcardMap.WILDCARD ) )
         {
-            logger.debug ("No version alignment to perform for relocations");
+            LOGGER.debug ("No version alignment to perform for relocations");
         }
         else
         {
@@ -179,7 +179,7 @@ public class RelocationManipulator
                 artifact = projectVersionRef.getArtifactId();
             }
 
-            logger.debug ("Adding dependencyExclusion {} & {}", projectVersionRef.getGroupId() + ':' + artifact + "@*",
+            LOGGER.debug ("Adding dependencyExclusion {} & {}", projectVersionRef.getGroupId() + ':' + artifact + "@*",
                           projectVersionRef.getVersionString() );
             state.updateExclusions( projectVersionRef.getGroupId() + ':' + artifact + "@*", projectVersionRef.getVersionString() );
         }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/RepoAndReportingRemovalManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/RepoAndReportingRemovalManipulator.java
@@ -49,7 +49,7 @@ public class RepoAndReportingRemovalManipulator
     implements Manipulator
 {
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( RepoAndReportingRemovalManipulator.class );
 
     @Requirement
     private SettingsIO settingsWriter;
@@ -85,7 +85,7 @@ public class RepoAndReportingRemovalManipulator
         final RepoReportingState state = session.getState( RepoReportingState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -99,7 +99,7 @@ public class RepoAndReportingRemovalManipulator
         for ( final Project project : projects )
         {
             final String ga = ga( project );
-            logger.info( "Applying changes to: " + ga );
+            LOGGER.info( "Applying changes to: " + ga );
             final Model model = project.getModel();
 
             Iterator<Repository> it = model.getRepositories().iterator();

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/RepositoryInjectionManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/RepositoryInjectionManipulator.java
@@ -46,7 +46,7 @@ import static org.commonjava.maven.ext.manip.util.IdUtils.ga;
 public class RepositoryInjectionManipulator
         implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( RepositoryInjectionManipulator.class );
 
     @Requirement
     private ModelIO modelBuilder;
@@ -82,7 +82,7 @@ public class RepositoryInjectionManipulator
         final RepositoryInjectionState state = session.getState( RepositoryInjectionState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -95,7 +95,7 @@ public class RepositoryInjectionManipulator
         for ( final Project project : projects )
         {
             final String ga = ga( project );
-            logger.info( "Applying changes to: " + ga );
+            LOGGER.info( "Applying changes to: " + ga );
             final Model model = project.getModel();
 
             if ( checkProject( state, project ) )
@@ -146,13 +146,13 @@ public class RepositoryInjectionManipulator
 
             if ( repository.getId().equals( r.getId() ) )
             {
-                logger.debug("Removing local repository {} ", r);
+                LOGGER.debug("Removing local repository {} ", r);
                 i.remove();
                 break;
             }
         }
 
-        logger.debug( "Adding repository {}", repository );
+        LOGGER.debug( "Adding repository {}", repository );
         repositories.add(repository);
     }
 
@@ -167,7 +167,7 @@ public class RepositoryInjectionManipulator
             {
                 result = true;
             }
-            logger.debug ("Checking project {} against possible GAs {} and found match {}", project.getKey().asProjectRef(), gaToApply, result);
+            LOGGER.debug ("Checking project {} against possible GAs {} and found match {}", project.getKey().asProjectRef(), gaToApply, result);
         }
         else if ( project.isInheritanceRoot() )
         {

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
  */
 public class Version
 {
-    private static final Logger logger = LoggerFactory.getLogger( Version.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( Version.class );
 
     private final static Character[] DEFAULT_DELIMITERS = { '.', '-', '_' };
 
@@ -117,11 +117,11 @@ public class Version
     public Version( String version )
     {
         originalVersion = version;
-        logger.debug( "Parsing version: " + originalVersion );
+        LOGGER.debug( "Parsing version: " + originalVersion );
         parseVersion( originalVersion );
-        logger.debug( "Major: " + getMajorVersion() + ", Minor: " + getMinorVersion() + ",  Micro: " +
+        LOGGER.debug( "Major: " + getMajorVersion() + ", Minor: " + getMinorVersion() + ",  Micro: " +
             getMicroVersion() );
-        logger.debug( "Qualifier: " + getQualifier() + ", Base: " + getQualifierBase() + ", BuildNum: " +
+        LOGGER.debug( "Qualifier: " + getQualifier() + ", Base: " + getQualifierBase() + ", BuildNum: " +
             getBuildNumber() );
     }
 
@@ -512,7 +512,7 @@ public class Version
             return;
         }
 
-        logger.debug( "Applying suffix: " + suffix + " to version " + getVersionString() );
+        LOGGER.debug( "Applying suffix: " + suffix + " to version " + getVersionString() );
         Matcher suffixMatcher = qualifierPattern.matcher( suffix );
         if ( !suffixMatcher.matches() )
         {
@@ -563,7 +563,7 @@ public class Version
         }
 
         updateQualifier();
-        logger.debug( "New version string: " + getVersionString() );
+        LOGGER.debug( "New version string: " + getVersionString() );
     }
 
     /**
@@ -625,7 +625,7 @@ public class Version
         versionPatternBuf.append( "(\\d+)" );
         String candidatePatternStr = versionPatternBuf.toString();
 
-        logger.debug( "Using pattern: '{}' to find compatible versions from metadata.", candidatePatternStr );
+        LOGGER.debug( "Using pattern: '{}' to find compatible versions from metadata.", candidatePatternStr );
         final Pattern candidateSuffixPattern = Pattern.compile( candidatePatternStr );
 
         for ( final String compareVersion : versionSet )
@@ -641,7 +641,7 @@ public class Version
                 }
             }
         }
-        logger.debug ("Found highest matching build number {} from set {} ", highestBuildNum, versionSet);
+        LOGGER.debug ("Found highest matching build number {} from set {} ", highestBuildNum, versionSet);
 
         return highestBuildNum;
     }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/VersionCalculator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/VersionCalculator.java
@@ -52,7 +52,7 @@ import static org.commonjava.maven.ext.manip.util.IdUtils.gav;
 @Component( role = VersionCalculator.class )
 public class VersionCalculator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( VersionCalculator.class );
 
     // Used by getMetadataVersions
     @Requirement
@@ -144,7 +144,7 @@ public class VersionCalculator
             }
 
             versionSet.add( modifiedVersionString );
-            logger.debug( gav( project ) + " has updated version: {}. Marking for rewrite.", modifiedVersionString );
+            LOGGER.debug( gav( project ) + " has updated version: {}. Marking for rewrite.", modifiedVersionString );
 
             if ( !originalVersion.equals( modifiedVersionString ) )
             {
@@ -175,10 +175,10 @@ public class VersionCalculator
         final String staticSuffix = state.getSuffix();
         final String override = state.getOverride();
 
-        logger.debug( "Got the following version:\n  Original version: " + version );
-        logger.debug( "Got the following version suffixes:\n  Static: " + staticSuffix + "\n  Incremental: " +
+        LOGGER.debug( "Got the following version:\n  Original version: " + version );
+        LOGGER.debug( "Got the following version suffixes:\n  Static: " + staticSuffix + "\n  Incremental: " +
             incrementalSuffix );
-        logger.debug( "Got the following override:\n  Version: " + override);
+        LOGGER.debug( "Got the following override:\n  Version: " + override);
 
         Version versionObj;
 
@@ -250,7 +250,7 @@ public class VersionCalculator
     private Set<String> getMetadataVersions( final String groupId, final String artifactId )
         throws ManipulationException
     {
-        logger.debug( "Reading available versions from repository metadata for: " + groupId + ":" + artifactId );
+        LOGGER.debug( "Reading available versions from repository metadata for: " + groupId + ":" + artifactId );
 
         try
         {

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/XMLManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/XMLManipulator.java
@@ -49,7 +49,7 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
 public class XMLManipulator
     implements Manipulator
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( XMLManipulator.class );
 
     private XPath xPath = XPathFactory.newInstance().newXPath();
 
@@ -85,7 +85,7 @@ public class XMLManipulator
         final XMLState state = session.getState( XMLState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            LOGGER.debug( getClass().getSimpleName() + ": Nothing to do!" );
             return Collections.emptySet();
         }
 
@@ -100,7 +100,7 @@ public class XMLManipulator
                 {
                     File target = new File( project.getPom().getParentFile(), operation.getFile() );
 
-                    logger.info( "Attempting to start XML update to file {} with xpath {} and replacement {}",
+                    LOGGER.info( "Attempting to start XML update to file {} with xpath {} and replacement {}",
                                  target, operation.getXPath(), operation.getUpdate() );
 
                     internalApplyChanges (target, operation);
@@ -147,7 +147,7 @@ public class XMLManipulator
         }
         catch ( XPathExpressionException e )
         {
-            logger.error( "Caught XML exception processing file {}, document context {} ", target, doc, e );
+            LOGGER.error( "Caught XML exception processing file {}, document context {} ", target, doc, e );
             throw new ManipulationException( "Caught XML exception processing file", e );
         }
     }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/GroovyState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/GroovyState.java
@@ -29,7 +29,7 @@ import java.util.Properties;
 public class GroovyState
     implements State
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( GroovyState.class );
 
     /**
      * The name of the property which contains a comma separated list of remote groovy scripts to load.

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/JSONState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/JSONState.java
@@ -32,7 +32,7 @@ import static org.apache.commons.lang.StringUtils.isNotEmpty;
 public class JSONState
     implements State
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( JSONState.class );
 
    /**
      * Property on the command line that handles modifying JSON files. The format is
@@ -75,7 +75,7 @@ public class JSONState
                 {
                     throw new ManipulationException( "Unable to parse command " + operation + " from property " + property );
                 }
-                logger.debug ("Adding JSONOperation with file {}, xpath {} and update {}", components[0], components[1], components[2] );
+                LOGGER.debug ("Adding JSONOperation with file {}, xpath {} and update {}", components[0], components[1], components[2] );
                 jsonOperations.add( new JSONOperation( components[0], components[1], components[2] ) );
             }
         }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/ProfileInjectionState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/ProfileInjectionState.java
@@ -34,7 +34,7 @@ import java.util.Properties;
 public class ProfileInjectionState
     implements State
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ProfileInjectionState.class );
 
     /**
      * Suffix to enable this modder
@@ -55,7 +55,7 @@ public class ProfileInjectionState
             }
             catch ( final InvalidRefException e )
             {
-                logger.error( "Skipping profile injection! Got invalid profileInjection GAV: {}", gav );
+                LOGGER.error( "Skipping profile injection! Got invalid profileInjection GAV: {}", gav );
                 throw e;
             }
         }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/ProfileRemovalState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/ProfileRemovalState.java
@@ -33,7 +33,7 @@ public class ProfileRemovalState
     implements State
 {
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ProfileRemovalState.class );
 
     /**
      * Suffix to enable this modder

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/RelocationState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/RelocationState.java
@@ -53,7 +53,7 @@ public class RelocationState
      */
     public static final String DEPENDENCY_RELOCATIONS = "dependencyRelocations.";
 
-    private static final Logger logger = LoggerFactory.getLogger( RelocationState.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( RelocationState.class );
 
     private final WildcardMap<ProjectVersionRef> dependencyRelocations = new WildcardMap<>();
 
@@ -110,7 +110,7 @@ public class RelocationState
 
             String version = ( isEmpty( entry.getValue() ) ? WildcardMap.WILDCARD : entry.getValue() );
 
-            logger.debug( "Relocation found oldGroupId '{}' : oldArtifactId '{}' -> newGroupId '{}' : newArtifactId '{}' and version '{}' ",
+            LOGGER.debug( "Relocation found oldGroupId '{}' : oldArtifactId '{}' -> newGroupId '{}' : newArtifactId '{}' and version '{}' ",
                           groupId, artifactId, newGroupId, newArtifactId, version );
 
             ProjectRef sp = new SimpleProjectRef( groupId, artifactId );
@@ -118,7 +118,7 @@ public class RelocationState
             dependencyRelocations.put( sp, new SimpleProjectVersionRef( newGroupId, newArtifactId, version ) );
         }
 
-        logger.trace ("Wildcard map {} ", dependencyRelocations);
+        LOGGER.trace ("Wildcard map {} ", dependencyRelocations);
     }
 
     /**

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/RepositoryInjectionState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/RepositoryInjectionState.java
@@ -34,7 +34,7 @@ import java.util.Properties;
 public class RepositoryInjectionState
     implements State
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( RepositoryInjectionState.class );
 
     /**
      * Suffix to enable this modder
@@ -61,7 +61,7 @@ public class RepositoryInjectionState
             }
             catch ( final InvalidRefException e )
             {
-                logger.error( "Skipping repository injection! Got invalid repositoryInjection GAV: {}", gav );
+                LOGGER.error( "Skipping repository injection! Got invalid repositoryInjection GAV: {}", gav );
                 throw e;
             }
         }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/state/XMLState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/state/XMLState.java
@@ -32,7 +32,7 @@ import static org.apache.commons.lang.StringUtils.isNotEmpty;
 public class XMLState
     implements State
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( XMLState.class );
 
    /**
      * Property on the command line that handles modifying XML files. The format is
@@ -75,7 +75,7 @@ public class XMLState
                 {
                     throw new ManipulationException( "Unable to parse command " + operation + " from property " + property );
                 }
-                logger.debug ("Adding XMLOperation with file {}, xpath {} and update {}", components[0], components[1], components[2] );
+                LOGGER.debug ("Adding XMLOperation with file {}, xpath {} and update {}", components[0], components[1], components[2] );
                 xmlOperations.add( new XMLOperation( components[0], components[1], components[2] ) );
             }
         }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/util/IdUtils.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/util/IdUtils.java
@@ -41,7 +41,7 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
  */
 public final class IdUtils
 {
-    private static final Logger logger = LoggerFactory.getLogger( IdUtils.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( IdUtils.class );
 
     private IdUtils()
     {
@@ -72,7 +72,7 @@ public final class IdUtils
                 }
                 catch ( final InvalidRefException e )
                 {
-                    logger.error( "Skipping invalid remote management GAV: " + gav );
+                    LOGGER.error( "Skipping invalid remote management GAV: " + gav );
                     throw e;
                 }
             }
@@ -106,7 +106,7 @@ public final class IdUtils
                 }
                 catch ( final InvalidRefException e )
                 {
-                    logger.error( "Skipping invalid remote management GAV: " + gav );
+                    LOGGER.error( "Skipping invalid remote management GAV: " + gav );
                     throw e;
                 }
             }
@@ -140,7 +140,7 @@ public final class IdUtils
                 }
                 catch ( final InvalidRefException e )
                 {
-                    logger.error( "Skipping invalid remote management GAV: " + gav );
+                    LOGGER.error( "Skipping invalid remote management GAV: " + gav );
                     throw e;
                 }
             }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
@@ -38,7 +38,7 @@ import java.util.Set;
  */
 public final class PropertiesUtils
 {
-    private final static Logger logger = LoggerFactory.getLogger( PropertiesUtils.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( PropertiesUtils.class );
 
     private PropertiesUtils()
     {
@@ -64,7 +64,7 @@ public final class PropertiesUtils
                 String value = properties.getProperty( propertyName );
                 if ( value != null && value.equals( "true" ) )
                 {
-                    logger.warn( "Work around Brew/Maven bug - removing erroneous 'true' value for {}.",
+                    LOGGER.warn( "Work around Brew/Maven bug - removing erroneous 'true' value for {}.",
                                  trimmedPropertyName );
                     value = "";
                 }
@@ -93,16 +93,16 @@ public final class PropertiesUtils
         PropertyUpdate found = PropertyUpdate.NOTFOUND;
 
         final String resolvedValue = resolveProperties( new ArrayList<>( projects ), "${" + key + '}' );
-        logger.debug( "Fully resolvedValue is {} for {} ", resolvedValue, key );
+        LOGGER.debug( "Fully resolvedValue is {} for {} ", resolvedValue, key );
 
         if ( resolvedValue.equals( newValue ) )
         {
-            logger.warn( "Nothing to update as original key {} value matches new value {} ", key, newValue );
+            LOGGER.warn( "Nothing to update as original key {} value matches new value {} ", key, newValue );
             return PropertyUpdate.IGNORE;
         }
         else if ( "project.version".equals( key ) )
         {
-            logger.warn( "Not updating key {} with {} ", key, newValue );
+            LOGGER.warn( "Not updating key {} with {} ", key, newValue );
             return PropertyUpdate.IGNORE;
         }
 
@@ -112,7 +112,7 @@ public final class PropertiesUtils
             {
                 final String oldValue = p.getModel().getProperties().getProperty( key );
 
-                logger.info( "Updating property {} / {} with {} ", key, oldValue, newValue );
+                LOGGER.info( "Updating property {} / {} with {} ", key, oldValue, newValue );
 
                 found = PropertyUpdate.FOUND;
 
@@ -126,12 +126,12 @@ public final class PropertiesUtils
                 if ( oldValue != null && oldValue.startsWith( "${" ) && oldValue.endsWith( "}" ) &&
                                 !( StringUtils.countMatches( oldValue, "${" ) > 1 ) )
                 {
-                    logger.debug( "Recursively resolving {} ", oldValue.substring( 2, oldValue.length() - 1 ) );
+                    LOGGER.debug( "Recursively resolving {} ", oldValue.substring( 2, oldValue.length() - 1 ) );
 
                     if ( updateProperties( session, projects, ignoreStrict,
                                             oldValue.substring( 2, oldValue.length() - 1 ), newValue ) == PropertyUpdate.NOTFOUND )
                     {
-                        logger.error( "Recursive property not found for {} with {} ", oldValue, newValue );
+                        LOGGER.error( "Recursive property not found for {} with {} ", oldValue, newValue );
                         return PropertyUpdate.NOTFOUND;
                     }
                 }
@@ -149,7 +149,7 @@ public final class PropertiesUtils
                             }
                             else
                             {
-                                logger.warn( "Replacing original property version {} with new version {} for {} violates the strict version-alignment rule!",
+                                LOGGER.warn( "Replacing original property version {} with new version {} for {} violates the strict version-alignment rule!",
                                              oldValue, newValue, key );
                                 // Ignore the dependency override. As found has been set to true it won't inject
                                 // a new property either.
@@ -177,7 +177,7 @@ public final class PropertiesUtils
                                             "NYI : handling for versions with explicit overrides (" + oldValue + ") with multiple embedded properties is NYI. " );
                         }
                         newValue = oldValue + StringUtils.removeStart( newValue, resolvedValue );
-                        logger.info( "Ignoring new value due to embedded property {} and appending {} ", oldValue,
+                        LOGGER.info( "Ignoring new value due to embedded property {} and appending {} ", oldValue,
                                      newValue );
                     }
 
@@ -243,12 +243,12 @@ public final class PropertiesUtils
                 oldValue = oldValue.substring( 0, oldValue.indexOf( suffix ) - 1 );
                 v = new Version( oldValue );
                 osgiVersion = v.getOSGiVersionString();
-                logger.debug( "Updating version to {} and osgiVersion {} for oldValue {} ", v, osgiVersion, oldValue );
+                LOGGER.debug( "Updating version to {} and osgiVersion {} for oldValue {} ", v, osgiVersion, oldValue );
 
             }
             else
             {
-                logger.warn( "strictIgnoreSuffix set but unable to align from {} to {}", oldValue, newValue );
+                LOGGER.warn( "strictIgnoreSuffix set but unable to align from {} to {}", oldValue, newValue );
             }
         }
 
@@ -264,7 +264,7 @@ public final class PropertiesUtils
         {
             newVersion = newValue.substring( 0, newValue.indexOf( suffix ) - 1 );
         }
-        logger.debug( "Comparing original version {} and OSGi variant {} with new version {} and suffix removed {} ",
+        LOGGER.debug( "Comparing original version {} and OSGi variant {} with new version {} and suffix removed {} ",
                       oldValue, osgiVersion, newValue, newVersion );
 
         // We compare both an OSGi'ied oldVersion and the non-OSGi version against the possible new version (which has
@@ -304,17 +304,17 @@ public final class PropertiesUtils
             if ( oldVersion.contains( "${" ) && !( oldVersion.startsWith( "${" ) && oldVersion.endsWith( "}" ) ) || (
                             StringUtils.countMatches( oldVersion, "${" ) > 1 ) )
             {
-                logger.debug( "For {} ; original version contains hardcoded value or multiple embedded properties. Not caching value ( {} -> {} )",
+                LOGGER.debug( "For {} ; original version contains hardcoded value or multiple embedded properties. Not caching value ( {} -> {} )",
                               originalType, oldVersion, newVersion );
             }
             else if ( "project.version".equals( oldProperty ) )
             {
-                logger.debug( "For {} ; original version was a property mapping. Not caching value as property is built-in ( {} -> {} )",
+                LOGGER.debug( "For {} ; original version was a property mapping. Not caching value as property is built-in ( {} -> {} )",
                               originalType, oldProperty, newVersion );
             }
             else
             {
-                logger.debug( "For {} ; original version was a property mapping; caching new value for update {} -> {}",
+                LOGGER.debug( "For {} ; original version was a property mapping; caching new value for update {} -> {}",
                               originalType, oldProperty, newVersion );
 
                 final String oldVersionProp = oldVersion.substring( 2, oldVersion.length() - 1 );
@@ -328,12 +328,12 @@ public final class PropertiesUtils
                 {
                     if ( force )
                     {
-                        logger.debug( "Override property replacement of {} with force version override {}",
+                        LOGGER.debug( "Override property replacement of {} with force version override {}",
                                       existingPropertyMapping, newVersion );
                     }
                     else
                     {
-                        logger.error( "Replacing property '{}' with a new version but the existing version does not match. Old value is {} and new is {}",
+                        LOGGER.error( "Replacing property '{}' with a new version but the existing version does not match. Old value is {} and new is {}",
                                       oldVersionProp, existingPropertyMapping, newVersion );
                         throw new ManipulationException(
                                         "Property replacement clash - updating property '{}' to both {} and {} ",

--- a/core/src/main/java/org/commonjava/maven/ext/manip/util/WildcardMap.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/util/WildcardMap.java
@@ -35,7 +35,7 @@ public class WildcardMap<T>
 {
     public static final String WILDCARD = "*";
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(WildcardMap.class);
 
     /**
      * This map represents:
@@ -119,7 +119,7 @@ public class WildcardMap<T>
             // Erase any previous mappings.
             if (!vMap.isEmpty())
             {
-                logger.warn ("Emptying map with keys " + vMap.keySet() + " as replacing with wildcard mapping " + key);
+                LOGGER.warn ("Emptying map with keys " + vMap.keySet() + " as replacing with wildcard mapping " + key);
             }
             vMap.clear();
         }
@@ -136,12 +136,12 @@ public class WildcardMap<T>
         }
         if ( wildcard )
         {
-            logger.warn ("Unable to add " + key + " with value " + value +
+            LOGGER.warn ("Unable to add " + key + " with value " + value +
                     " as wildcard mapping for " + groupId + " already exists.");
         }
         else
         {
-            logger.debug ("Entering artifact of " + artifactId + " and value " + value);
+            LOGGER.debug ("Entering artifact of " + artifactId + " and value " + value);
             vMap.put(artifactId, value);
 
             map.put(groupId, vMap);
@@ -184,7 +184,7 @@ public class WildcardMap<T>
         LinkedHashMap<String, T> value = map.get(groupId);
         if (value != null)
         {
-            logger.debug("Retrieved value map of " + value);
+            LOGGER.debug("Retrieved value map of " + value);
             if ( value.get(WILDCARD) != null)
             {
                 result = value.get(WILDCARD);
@@ -194,7 +194,7 @@ public class WildcardMap<T>
                 result = value.get(artifactId);
             }
         }
-        logger.debug("Returning result of " + result);
+        LOGGER.debug("Returning result of " + result);
 
         return result;
     }

--- a/ext/src/main/java/org/commonjava/maven/ext/manip/ManipulatingEventSpy.java
+++ b/ext/src/main/java/org/commonjava/maven/ext/manip/ManipulatingEventSpy.java
@@ -42,7 +42,7 @@ public class ManipulatingEventSpy
 
     private static final String REQUIRE_EXTENSION = "manipulation.required";
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ManipulatingEventSpy.class );
 
     @Requirement
     private ManipulationManager manipulationManager;
@@ -108,24 +108,24 @@ public class ManipulatingEventSpy
                     }
                     else
                     {
-                        logger.error( "Null session ; unable to continue" );
+                        LOGGER.error( "Null session ; unable to continue" );
                         return;
                     }
 
                     if ( !session.isEnabled() )
                     {
-                        logger.info( "Manipulation engine disabled via command-line option" );
+                        LOGGER.info( "Manipulation engine disabled via command-line option" );
                         return;
                     }
                     else if ( ee.getSession().getRequest().getPom() == null )
                     {
-                        logger.info( "Manipulation engine disabled. No project found." );
+                        LOGGER.info( "Manipulation engine disabled. No project found." );
                         return;
                     }
                     else if ( new File( ee.getSession().getRequest().getPom().getParentFile(),
                                         ManipulationManager.MARKER_FILE ).exists() )
                     {
-                        logger.info( "Skipping manipulation as previous execution found." );
+                        LOGGER.info( "Skipping manipulation as previous execution found." );
                         return;
                     }
 
@@ -135,7 +135,7 @@ public class ManipulatingEventSpy
         }
         catch ( final ManipulationException e )
         {
-            logger.error( "Extension failure", e );
+            LOGGER.error( "Extension failure", e );
             if ( required )
             {
                 throw e;
@@ -148,7 +148,7 @@ public class ManipulatingEventSpy
         // Catch any runtime exceptions and mark them to fail the build as well.
         catch ( final RuntimeException e )
         {
-            logger.error( "Extension failure", e );
+            LOGGER.error( "Extension failure", e );
             if ( required )
             {
                 throw e;

--- a/io/src/main/java/org/commonjava/maven/ext/manip/io/ConfigIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/io/ConfigIO.java
@@ -36,7 +36,7 @@ import java.util.Properties;
 @Component( role = ConfigIO.class )
 public class ConfigIO
 {
-    private final Logger logger = LoggerFactory.getLogger( ConfigIO.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ConfigIO.class );
 
     private final static String propertyFileString = "pme.properties";
     private final static String yamlPMEFileString = "pme.yaml";
@@ -71,12 +71,12 @@ public class ConfigIO
         if ( yamlPMEFile.exists() )
         {
             result = loadYamlFile( yamlPMEFile );
-            logger.debug( "Read yaml file containing {}.", result );
+            LOGGER.debug( "Read yaml file containing {}.", result );
         }
         else if ( yamlPNCFile.exists() )
         {
             result = loadYamlFile( yamlPNCFile );
-            logger.debug( "Read yaml file containing {}.", result );
+            LOGGER.debug( "Read yaml file containing {}.", result );
         }
         else if ( jsonPNCFile.exists() )
         {
@@ -88,12 +88,12 @@ public class ConfigIO
             {
                 throw new ManipulationException( "Caught exception processing JSON file.", e );
             }
-            logger.debug( "Read json file containing {}.", result );
+            LOGGER.debug( "Read json file containing {}.", result );
         }
         else if ( propertyFile.exists() )
         {
             result = loadPropertiesFile( propertyFile );
-            logger.debug( "Read properties file containing {}.", result );
+            LOGGER.debug( "Read properties file containing {}.", result );
         }
         return result;
     }

--- a/io/src/main/java/org/commonjava/maven/ext/manip/io/JSONIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/io/JSONIO.java
@@ -38,7 +38,7 @@ import java.nio.charset.StandardCharsets;
 @Component( role = JSONIO.class )
 public class JSONIO
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( JSONIO.class );
 
     private ObjectMapper mapper = new ObjectMapper( );
 
@@ -59,7 +59,7 @@ public class JSONIO
         }
         catch ( IOException e )
         {
-            logger.error( "Unable to parse JSON File {} ", e );
+            LOGGER.error( "Unable to parse JSON File {} ", e );
             throw new ManipulationException( "Unable to parse JSON File", e );
         }
         return doc;
@@ -81,7 +81,7 @@ public class JSONIO
         }
         catch ( IOException e )
         {
-            logger.error( "Unable to write JSON string:  ", e );
+            LOGGER.error( "Unable to write JSON string:  ", e );
             throw new ManipulationException( "Unable to write JSON string", e );
         }
     }

--- a/io/src/main/java/org/commonjava/maven/ext/manip/io/ModelIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/io/ModelIO.java
@@ -77,7 +77,7 @@ public class ModelIO
         }
     }
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ModelIO.class );
 
     @Requirement
     private GalleyAPIWrapper galleyWrapper;
@@ -154,7 +154,7 @@ public class ModelIO
     public Map<ArtifactRef, String> getRemoteDependencyVersionOverrides( final ProjectVersionRef ref )
                     throws ManipulationException
     {
-        logger.debug( "Resolving dependency management GAV: " + ref );
+        LOGGER.debug( "Resolving dependency management GAV: " + ref );
 
         final Map<ArtifactRef, String> versionOverrides = new LinkedHashMap<>();
         try
@@ -165,14 +165,14 @@ public class ModelIO
             final List<DependencyView> deps = pomView.getAllManagedDependencies();
             if ( deps == null || deps.isEmpty() )
             {
-                logger.warn( "Attempting to align to a BOM that does not have a dependencyManagement section" );
+                LOGGER.warn( "Attempting to align to a BOM that does not have a dependencyManagement section" );
             }
             else
             {
                 for ( final DependencyView dep : deps )
                 {
                     versionOverrides.put( dep.asArtifactRef(), dep.getVersion() );
-                    logger.debug( "Added version override for: " + dep.asProjectRef().toString() + ":" + dep.getVersion() );
+                    LOGGER.debug( "Added version override for: " + dep.asProjectRef().toString() + ":" + dep.getVersion() );
                 }
             }
         }
@@ -187,11 +187,11 @@ public class ModelIO
     public Properties getRemotePropertyMappingOverrides( final ProjectVersionRef ref )
                     throws ManipulationException
     {
-        logger.debug( "Resolving remote property mapping POM: " + ref );
+        LOGGER.debug( "Resolving remote property mapping POM: " + ref );
 
         final Model m = resolveRawModel( ref );
 
-        logger.debug( "Returning override of " + m.getProperties() );
+        LOGGER.debug( "Returning override of " + m.getProperties() );
 
         return m.getProperties();
     }
@@ -229,7 +229,7 @@ public class ModelIO
                                                                      Properties userProperties )
                     throws ManipulationException
     {
-        logger.debug( "Resolving remote {} POM: {}", type, ref );
+        LOGGER.debug( "Resolving remote {} POM: {}", type, ref );
         final Map<ProjectRef, Plugin> pluginOverrides = new HashMap<>();
         final Map<ProjectRef, ProjectVersionRef> pluginOverridesPomView = new HashMap<>();
 
@@ -257,7 +257,7 @@ public class ModelIO
             throw new ManipulationException( "Unable to resolve: %s", e, ref );
         }
 
-        logger.debug( "Found pluginOverridesResolvedVersions {} " + pluginOverridesPomView );
+        LOGGER.debug( "Found pluginOverridesResolvedVersions {} " + pluginOverridesPomView );
 
         // The list of pluginOverridesPomView may be larger than those in current model pluginMgtm. Dummy up an extra
         // set of plugins with versions to handle those.
@@ -270,7 +270,7 @@ public class ModelIO
 
             pluginOverrides.put( entry.getKey(), p );
 
-            logger.debug( "Added plugin override for: " + entry.getKey().toString() + ":" + p.getVersion() );
+            LOGGER.debug( "Added plugin override for: " + entry.getKey().toString() + ":" + p.getVersion() );
         }
 
         // TODO: active profiles!
@@ -280,12 +280,12 @@ public class ModelIO
 
             if ( type == PluginType.PluginMgmt && m.getBuild().getPluginManagement() != null )
             {
-                logger.debug( "Returning override of " + m.getBuild().getPluginManagement().getPlugins() );
+                LOGGER.debug( "Returning override of " + m.getBuild().getPluginManagement().getPlugins() );
                 plit = m.getBuild().getPluginManagement().getPlugins().iterator();
             }
             else if ( type == PluginType.Plugins && m.getBuild().getPlugins() != null)
             {
-                logger.debug( "Returning override of " + m.getBuild().getPlugins() );
+                LOGGER.debug( "Returning override of " + m.getBuild().getPlugins() );
                 plit = m.getBuild().getPlugins().iterator();
             }
 
@@ -306,7 +306,7 @@ public class ModelIO
                         newVersion = pluginOverridesPomView.get( pr ).getVersionString();
                     }
 
-                    logger.debug( "Replacing plugin override version " + p.getVersion() +
+                    LOGGER.debug( "Replacing plugin override version " + p.getVersion() +
                                                   " with " + newVersion );
                      p.setVersion( newVersion );
                 }
@@ -338,7 +338,7 @@ public class ModelIO
                     {
                         if ( ! isEmpty(d.getVersion()) && d.getVersion().startsWith( "${" ) )
                         {
-                            logger.debug( "Processing dependency {} and updating with {} ", d,
+                            LOGGER.debug( "Processing dependency {} and updating with {} ", d,
                                           resolveProperty( userProperties, m.getProperties(), d.getVersion() ) );
                             d.setVersion( resolveProperty( userProperties, m.getProperties(), d.getVersion() ) );
 
@@ -346,7 +346,7 @@ public class ModelIO
                     }
                 }
 
-                logger.debug( "Added plugin override for: " + pr.toString() + ":" + p.getVersion() +
+                LOGGER.debug( "Added plugin override for: " + pr.toString() + ":" + p.getVersion() +
                                               " with configuration\n" + p.getConfiguration() + " and executions "
                                               + p.getExecutions() );
             }
@@ -381,7 +381,7 @@ public class ModelIO
 
                 if ( replacement != null && !replacement.isEmpty() )
                 {
-                    logger.debug( "Replacing child value " + child.getValue() + " with " + replacement );
+                    LOGGER.debug( "Replacing child value " + child.getValue() + " with " + replacement );
                     child.setValue( replacement );
                 }
             }

--- a/io/src/main/java/org/commonjava/maven/ext/manip/io/PomIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/io/PomIO.java
@@ -64,7 +64,7 @@ public class PomIO
 {
     private static final String MODIFIED_BY = "[Comment: <!-- Modified by POM Manipulation Extension for Maven";
 
-    private static final Logger logger = LoggerFactory.getLogger( PomIO.class );
+    private static final Logger LOGGER = LoggerFactory.getLogger( PomIO.class );
 
 
     public List<Project> parseProject (final File pom) throws ManipulationException
@@ -122,7 +122,7 @@ public class PomIO
 
             if ( executionRoot.equals( pom ))
             {
-                logger.debug( "Setting execution root to {} with file {}" +
+                LOGGER.debug( "Setting execution root to {} with file {}" +
                       (project.isInheritanceRoot() ? " and is the inheritance root. ": ""), project, pom );
                 project.setExecutionRoot ();
             }
@@ -145,11 +145,11 @@ public class PomIO
     {
         for ( final Project project : changed )
         {
-            logger.info( String.format( "%s modified! Rewriting.", project ) );
+            LOGGER.info( String.format( "%s modified! Rewriting.", project ) );
             File pom = project.getPom();
 
             final Model model = project.getModel();
-            logger.trace( "Rewriting: " + model.toString() + " in place of: " + project.getId()
+            LOGGER.trace( "Rewriting: " + model.toString() + " in place of: " + project.getId()
                          + "\n       to POM: " + pom );
 
             write( project, pom, model );
@@ -283,7 +283,7 @@ public class PomIO
                 final File pom = pendingPoms.removeFirst();
                 seen.add( pom );
 
-                logger.debug( "PEEK: " + pom );
+                LOGGER.debug( "PEEK: " + pom );
 
                 final PomPeek peek = new PomPeek( pom );
                 final ProjectVersionRef key = peek.getKey();
@@ -296,7 +296,7 @@ public class PomIO
                     final String relPath = peek.getParentRelativePath();
                     if ( relPath != null )
                     {
-                        logger.debug( "Found parent relativePath: " + relPath + " in pom: " + pom );
+                        LOGGER.debug( "Found parent relativePath: " + relPath + " in pom: " + pom );
                         File parent = new File( dir, relPath );
                         if ( parent.isDirectory() )
                         {
@@ -310,12 +310,12 @@ public class PomIO
                             && !pendingPoms.contains( parent ) )
                         {
                             topLevelParent = parent;
-                            logger.debug( "Possible top level parent " + parent );
+                            LOGGER.debug( "Possible top level parent " + parent );
                             pendingPoms.add( parent );
                         }
                         else
                         {
-                            logger.debug( "Skipping reference to non-existent parent relativePath: '" + relPath
+                            LOGGER.debug( "Skipping reference to non-existent parent relativePath: '" + relPath
                                 + "' in: " + pom );
                         }
                     }
@@ -325,7 +325,7 @@ public class PomIO
                     {
                         for ( final String module : modules )
                         {
-                            logger.debug( "Found module: " + module + " in pom: " + pom );
+                            LOGGER.debug( "Found module: " + module + " in pom: " + pom );
 
                             File modPom = new File( dir, module );
                             if ( modPom.isDirectory() )
@@ -340,14 +340,14 @@ public class PomIO
                             }
                             else
                             {
-                                logger.debug( "Skipping reference to non-existent module: '" + module + "' in: " + pom );
+                                LOGGER.debug( "Skipping reference to non-existent module: '" + module + "' in: " + pom );
                             }
                         }
                     }
                 }
                 else
                 {
-                    logger.debug( "Skipping " + pom + " as its a template file." );
+                    LOGGER.debug( "Skipping " + pom + " as its a template file." );
                 }
             }
 
@@ -360,19 +360,19 @@ public class PomIO
                 if ( p.getPom()
                       .equals( topLevelParent ) )
                 {
-                    logger.debug( "Setting top level parent to " + p.getPom() + " :: " + p.getKey() );
+                    LOGGER.debug( "Setting top level parent to " + p.getPom() + " :: " + p.getKey() );
                     p.setInheritanceRoot( true );
                 }
             }
 
-            logger.debug( "Searching pom list " + projectrefs.toString() + " for standalone poms..." );
+            LOGGER.debug( "Searching pom list " + projectrefs.toString() + " for standalone poms..." );
 
             for ( final PomPeek p : peeked )
             {
                 if ( p.getParentKey() == null ||
                      ! seenThisParent(projectrefs, p.getParentKey()))
                 {
-                    logger.debug( "Found a standalone pom " + p.getPom() + " :: " + p.getKey() );
+                    LOGGER.debug( "Found a standalone pom " + p.getPom() + " :: " + p.getKey() );
                     p.setInheritanceRoot( true );
                 }
             }

--- a/io/src/main/java/org/commonjava/maven/ext/manip/io/SettingsIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/io/SettingsIO.java
@@ -37,7 +37,7 @@ import java.util.Iterator;
 @Component( role = SettingsIO.class )
 public class SettingsIO
 {
-    protected final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( SettingsIO.class );
 
     @Requirement
     private SettingsBuilder settingsBuilder;

--- a/io/src/main/java/org/commonjava/maven/ext/manip/io/XMLIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/io/XMLIO.java
@@ -40,7 +40,7 @@ import java.io.StringWriter;
 @Component( role = XMLIO.class )
 public class XMLIO
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( XMLIO.class );
 
     private final DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
     private final DocumentBuilder builder;
@@ -59,12 +59,12 @@ public class XMLIO
         }
         catch ( ParserConfigurationException e )
         {
-            logger.error( "Unable to create new DocumentBuilder", e );
+            LOGGER.error( "Unable to create new DocumentBuilder", e );
             throw new RuntimeException("Unable to create new DocumentBuilder" );
         }
         catch ( TransformerConfigurationException e )
         {
-            logger.error( "Unable to create new Transformer", e );
+            LOGGER.error( "Unable to create new Transformer", e );
             throw new RuntimeException("Unable to create new Transformer" );
         }
     }
@@ -74,7 +74,7 @@ public class XMLIO
     {
         if ( xmlFile == null || !xmlFile.exists() )
         {
-            logger.error( "Unable to locate XML File {} ", xmlFile );
+            LOGGER.error( "Unable to locate XML File {} ", xmlFile );
             throw new ManipulationException( "XML file (" + xmlFile + ") not found.");
         }
         Document doc;
@@ -84,7 +84,7 @@ public class XMLIO
         }
         catch ( SAXException | IOException e )
         {
-            logger.error( "Unable to parse XML File {} ", e );
+            LOGGER.error( "Unable to parse XML File {} ", e );
             throw new ManipulationException( "Unable to parse XML File", e );
         }
         return doc;
@@ -106,7 +106,7 @@ public class XMLIO
         }
         catch ( IOException e )
         {
-            logger.error( "XML transformer failure", e );
+            LOGGER.error( "XML transformer failure", e );
             throw new ManipulationException( "XML transformer failure", e );
         }
     }
@@ -121,7 +121,7 @@ public class XMLIO
         }
         catch ( TransformerException e )
         {
-            logger.error( "XML transformer failure", e );
+            LOGGER.error( "XML transformer failure", e );
             throw new ManipulationException( "XML transformer failure", e );
         }
         return outWriter.toString();

--- a/io/src/main/java/org/commonjava/maven/ext/manip/resolver/MavenLocationExpander.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/resolver/MavenLocationExpander.java
@@ -68,7 +68,7 @@ public class MavenLocationExpander
 
     private final List<Location> locations;
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( MavenLocationExpander.class );
 
     public MavenLocationExpander( final List<Location> customLocations,
                                   final List<ArtifactRepository> artifactRepositories,
@@ -92,7 +92,7 @@ public class MavenLocationExpander
         addSettingsProfileRepositoriesTo( locs, settings, activeProfiles, mirrorSelector );
         addRequestRepositoriesTo( locs, artifactRepositories, settings, mirrorSelector );
 
-        logger.debug( "Configured to use Maven locations:\n  {}", new JoinString( "\n  ", locs ) );
+        LOGGER.debug( "Configured to use Maven locations:\n  {}", new JoinString( "\n  ", locs ) );
         this.locations = new ArrayList<>( locs );
     }
 
@@ -227,7 +227,7 @@ public class MavenLocationExpander
             expandSingle( loc, result );
         }
 
-        logger.debug( "Expanded to:\n {}", new JoinString( "\n  ", result ) );
+        LOGGER.debug( "Expanded to:\n {}", new JoinString( "\n  ", result ) );
         return result;
     }
 
@@ -241,7 +241,7 @@ public class MavenLocationExpander
             expandSingle( loc, result );
         }
 
-        logger.debug( "Expanded to:\n {}", new JoinString( "\n  ", result ) );
+        LOGGER.debug( "Expanded to:\n {}", new JoinString( "\n  ", result ) );
         return result;
     }
 
@@ -262,7 +262,7 @@ public class MavenLocationExpander
             }
         }
 
-        logger.debug( "Expanded to:\n {}", new JoinString( "\n  ", result ) );
+        LOGGER.debug( "Expanded to:\n {}", new JoinString( "\n  ", result ) );
         return new VirtualResource( result );
     }
 
@@ -281,15 +281,15 @@ public class MavenLocationExpander
 
     private void expandSingle( final Location loc, final List<Location> result )
     {
-        logger.debug( "Expanding: {}", loc );
+        LOGGER.debug( "Expanding: {}", loc );
         if ( EXPANSION_TARGET.equals( loc ) )
         {
-            logger.debug( "Expanding..." );
+            LOGGER.debug( "Expanding..." );
             result.addAll( this.locations );
         }
         else
         {
-            logger.debug( "No expansion available." );
+            LOGGER.debug( "No expansion available." );
             result.add( loc );
         }
     }

--- a/io/src/main/java/org/commonjava/maven/ext/manip/rest/DefaultVersionTranslator.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/rest/DefaultVersionTranslator.java
@@ -50,7 +50,7 @@ public class DefaultVersionTranslator
 
     private static final int CHUNK_SPLIT_COUNT = 4;
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( DefaultVersionTranslator.class );
 
     private final String endpointUrl;
 
@@ -89,16 +89,16 @@ public class DefaultVersionTranslator
                 {
                     if ( task.getStatus() < 0 )
                     {
-                        logger.debug ("Caught exception calling server with message {}", task.getException().getMessage());
+                        LOGGER.debug ("Caught exception calling server with message {}", task.getException().getMessage());
                     }
                     else
                     {
-                        logger.debug ("Did not get status {} but received {}", SC_OK, task.getStatus());
+                        LOGGER.debug ("Did not get status {} but received {}", SC_OK, task.getStatus());
                     }
 
                     List<Task> tasks = task.split();
 
-                    logger.warn( "Failed to translate versions for task @{}, splitting and retrying. Chunk size was: {} and new chunk size {} in {} segments.",
+                    LOGGER.warn( "Failed to translate versions for task @{}, splitting and retrying. Chunk size was: {} and new chunk size {} in {} segments.",
                                  task.hashCode(), task.getChunkSize(), tasks.get( 0 ).getChunkSize(), tasks.size());
                     queue.addAll( tasks );
                 }

--- a/io/src/main/java/org/commonjava/maven/ext/manip/rest/mapper/ProjectVersionRefMapper.java
+++ b/io/src/main/java/org/commonjava/maven/ext/manip/rest/mapper/ProjectVersionRefMapper.java
@@ -34,7 +34,7 @@ import java.util.Map;
  */
 public class ProjectVersionRefMapper implements ObjectMapper
 {
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private static final Logger LOGGER = LoggerFactory.getLogger( ProjectVersionRefMapper.class );
 
     private final com.fasterxml.jackson.databind.ObjectMapper objectMapper
         = new com.fasterxml.jackson.databind.ObjectMapper();
@@ -50,18 +50,18 @@ public class ProjectVersionRefMapper implements ObjectMapper
 
         if (s.length() == 0)
         {
-            logger.error( "No content to read.");
+            LOGGER.error( "No content to read.");
             return result;
         }
         else if (s.startsWith( "<" ))
         {
             // Read an HTML string.
-            logger.error( "Read HTML string '{}' rather than a JSON stream.", s );
+            LOGGER.error( "Read HTML string '{}' rather than a JSON stream.", s );
             return result;
         }
         else if (s.startsWith( "{\\\"message\\\":" ) || s.startsWith( "{\"message\":" ))
         {
-            logger.error( "Read message string {}", s );
+            LOGGER.error( "Read message string {}", s );
             return result;
         }
 
@@ -72,7 +72,7 @@ public class ProjectVersionRefMapper implements ObjectMapper
         }
         catch ( IOException e )
         {
-            logger.error( "Failed to decode map when reading string {}", s );
+            LOGGER.error( "Failed to decode map when reading string {}", s );
             throw new RestException( "Failed to read list-of-maps response from version server: " + e.getMessage(), e );
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1312 - Loggers should be "private static final" and should share a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1312

Please let me know if you have any questions.

M-Ezzat