### PR TITLE
Also populateDefaults for MavenRequests for CLI mode

### DIFF
--- a/cli/src/main/java/org/commonjava/maven/ext/manip/Cli.java
+++ b/cli/src/main/java/org/commonjava/maven/ext/manip/Cli.java
@@ -72,7 +72,6 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -458,7 +457,9 @@ public class Cli
 
                 MavenExecutionRequestPopulator executionRequestPopulator =
                     container.lookup( MavenExecutionRequestPopulator.class );
+
                 executionRequestPopulator.populateFromSettings( req, parseSettings( settings ) );
+                executionRequestPopulator.populateDefaults( req );
             }
 
             final MavenSession mavenSession =


### PR DESCRIPTION
@jdcasey A settings file with just a mirrorOf section and no profiles was not being picked up. This change picks it up now.