### PR TITLE
Refactor version modifications to be stateless

### DIFF
--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
@@ -30,8 +30,9 @@ import java.util.regex.Pattern;
  * OSGi versioning. Parses versions into the following format: &lt;major&gt;.&lt;minor&gt;.&lt;micro&gt;
  * .&lt;qualifierBase&gt;-&lt;buildnumber&gt;-&lt;buildnumber&gt;-&lt;snapshot&gt;
  */
-public class Version {
-    private static final Logger logger = LoggerFactory.getLogger(Version.class);
+public class Version
+{
+    private static final Logger logger = LoggerFactory.getLogger( Version.class );
 
     private final static String EMPTY_STRING = "";
 

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
@@ -53,7 +53,7 @@ public class Version {
     /**
      * Regular expression used to match version string delimiters
      */
-    private final static String DELIMITER_REGEX = "[\\.\\-_]";
+    private final static String DELIMITER_REGEX = "[.\\-_]";
 
     /**
      * Regular expression used to match version string delimiters
@@ -92,7 +92,7 @@ public class Version {
     /**
      * Used to match valid OSGi version based on section 3.2.5 of the OSGi specification
      */
-    private final static String OSGI_VERSION_REGEX = "(\\d+)(\\.\\d+(\\.\\d+([\\.][\\w\\-_]+)?)?)?";
+    private final static String OSGI_VERSION_REGEX = "(\\d+)(\\.\\d+(\\.\\d+(\\.[\\w\\-_]+)?)?)?";
 
     private final static Pattern osgiPattern = Pattern.compile(OSGI_VERSION_REGEX);
 
@@ -121,7 +121,7 @@ public class Version {
      *
      * @param version The version to parse
      * @param fill Whether to fill the minor and micro versions with zeros if they are missing
-     * @return
+     * @return OSGi formatted major, minor, micro
      */
     static String getOsgiMMM(String version, boolean fill)
     {
@@ -236,11 +236,7 @@ public class Version {
 
     public static boolean isEmpty( String string )
     {
-        if ( string == null )
-        {
-            return true;
-        }
-        if ( string.trim().equals( EMPTY_STRING ) )
+        if ( string == null || string.trim().equals( EMPTY_STRING ) )
         {
             return true;
         }
@@ -265,9 +261,6 @@ public class Version {
 
     /**
      * Remove the build number (and associated delimiter) portion of the version string
-     *
-     * @param version
-     * @return
      */
     public static String removeBuildNumber( String version )
     {
@@ -280,10 +273,8 @@ public class Version {
     }
 
     /**
-     * Remove the snapshot (and associated delimiter) portion of the version string
-     *
-     * @param version
-     * @return
+     * Remove the snapshot (and associated delimiter) portion of the version string.
+     * Converts something like "1.0-SNAPSHOT" to "1.0"
      */
     public static String removeSnapshot( String version )
     {
@@ -295,7 +286,7 @@ public class Version {
         return version;
     }
 
-    static boolean hasLeadingDelimiter( String versionPart )
+    private static boolean hasLeadingDelimiter( String versionPart )
     {
         if ( versionPart.length() < 1 )
         {
@@ -306,9 +297,6 @@ public class Version {
 
     /**
      * Remove any leading delimiters from the partial version string
-     *
-     * @param versionPart
-     * @return
      */
     static String removeLeadingDelimiter(String versionPart )
     {
@@ -328,28 +316,12 @@ public class Version {
     }
 
     /**
-     * Remove any delimiters from the end of the string
-     * //TODO: maybe remove this method
-     * @param partialVersionString
-     * @return
-     */
-    private String removeLastDelimiters( String partialVersionString )
-    {
-        while ( !isEmpty( partialVersionString ) &&
-            versionStringDelimiters.contains( partialVersionString.charAt( partialVersionString.length() - 1 ) ) )
-        {
-            partialVersionString = partialVersionString.substring( 0, partialVersionString.length() - 1 );
-        }
-        return partialVersionString;
-    }
-
-    /**
      * Check if all the characters in the string are digits
      *
      * @param str a string to check
      * @return whether all the characters in the string are digits
      */
-    static boolean isNumeric( String str )
+    private static boolean isNumeric( String str )
     {
         for ( char c : str.toCharArray() )
         {
@@ -452,6 +424,12 @@ public class Version {
      */
     public static String setBuildNumber( String version, String buildNumber )
     {
+        if ( !isNumeric( buildNumber ) )
+        {
+            logger.warn("Failed attempt to set non-numeric build number '" + buildNumber + "' for version '"
+                    + version + "'");
+            return version;
+        }
         if ( isEmpty( buildNumber ) )
         {
             buildNumber = EMPTY_STRING;

--- a/core/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/impl/Version.java
@@ -30,13 +30,25 @@ import java.util.regex.Pattern;
  * OSGi versioning. Parses versions into the following format: &lt;major&gt;.&lt;minor&gt;.&lt;micro&gt;
  * .&lt;qualifierBase&gt;-&lt;buildnumber&gt;-&lt;buildnumber&gt;-&lt;snapshot&gt;
  */
-public class Version
-{
-    private static final Logger logger = LoggerFactory.getLogger( Version.class );
+public class Version {
+    private static final Logger logger = LoggerFactory.getLogger(Version.class);
 
-    private final static Character[] DEFAULT_DELIMITERS = { '.', '-', '_' };
+    private final static String EMPTY_STRING = "";
 
-    private final static char OSGI_VERSION_DELIMITER = '.';
+    private final static Character[] DEFAULT_DELIMITERS = {'.', '-', '_'};
+
+    private final static String OSGI_VERSION_DELIMITER = ".";
+
+    private final static String OSGI_QUALIFIER_DELIMITER = "-";
+
+    private final static String DEFAULT_DELIMITER = ".";
+
+    /**
+     * The default delimiter between the different parts of the qualifier
+     */
+    private final static String DEFAULT_QUALIFIER_DELIMITER = "-";
+
+    private final static List<Character> versionStringDelimiters = Arrays.asList( DEFAULT_DELIMITERS );
 
     /**
      * Regular expression used to match version string delimiters
@@ -44,197 +56,280 @@ public class Version
     private final static String DELIMITER_REGEX = "[\\.\\-_]";
 
     /**
+     * Regular expression used to match version string delimiters
+     */
+    private final static String LEADING_DELIMITER_REGEX = "^" + DELIMITER_REGEX;
+
+    /**
      * Regular expression used to match the major, minor, and micro versions
      */
-    private final static String MMM_REGEX = "(\\d+)(" + DELIMITER_REGEX + "(\\d+)?(" + DELIMITER_REGEX + "(\\d+))?)?";
+    private final static String MMM_REGEX = "(\\d+)(" + DELIMITER_REGEX + "(\\d+)(" + DELIMITER_REGEX + "(\\d+))?)?";
 
-    private final static Pattern mmmPattern = Pattern.compile( MMM_REGEX );
+    private final static Pattern mmmPattern = Pattern.compile(MMM_REGEX);
 
     private final static String SNAPSHOT_SUFFIX = "SNAPSHOT";
+
+    private final static String SNAPSHOT_REGEX = "(.*?)((" + DELIMITER_REGEX + ")?((?i:" + SNAPSHOT_SUFFIX + ")))$";
+
+    private final static Pattern snapshotPattern = Pattern.compile(SNAPSHOT_REGEX);
 
     /**
      * Regular expression used to match the parts of the qualifier "base-buildnum-snapshot"
      */
-    private final static String QUALIFIER_REGEX = "(.*?)((" + DELIMITER_REGEX + ")?(\\d+))?$";
+    private final static String QUALIFIER_REGEX = "(.*?)((" + DELIMITER_REGEX + ")?(\\d+))?((" + DELIMITER_REGEX + ")?((?i:" + SNAPSHOT_SUFFIX + ")))?$";
 
-    private final static Pattern qualifierPattern = Pattern.compile( QUALIFIER_REGEX );
-
-    private final static String VERSION_REGEX = "(" + MMM_REGEX + ")?" + "(" + DELIMITER_REGEX + ")?"
-            + "(" + QUALIFIER_REGEX + ")";
-
-    private final static Pattern versionPattern = Pattern.compile( VERSION_REGEX );
-
-    private final static String SNAPSHOT_REGEX = "(.*?)((" + DELIMITER_REGEX + ")?((?i:" + SNAPSHOT_SUFFIX + ")))?$";
-
-    private final static Pattern snapshotPattern = Pattern.compile( SNAPSHOT_REGEX );
+    private final static Pattern qualifierPattern = Pattern.compile(QUALIFIER_REGEX);
 
     /**
-     * Used to match valid OSGi version
+     * Version string must start with a digit to match the regex.  Otherwise we have only a
+     * qualifier.
      */
-    private final static String OSGI_VERSION_REGEX = "(\\d+)(\\.\\d+(\\.\\d+([\\.][\\p{Alnum}|\\-_]+)?)?)?";
+    private final static String VERSION_REGEX = "(" + MMM_REGEX + ")" + "((" + DELIMITER_REGEX + ")?"
+            + "(" + QUALIFIER_REGEX + "))";
 
-    private final static Pattern osgiPattern = Pattern.compile( OSGI_VERSION_REGEX );
-
-    private final List<Character> versionStringDelimiters = Arrays.asList( DEFAULT_DELIMITERS );
+    private final static Pattern versionPattern = Pattern.compile(VERSION_REGEX);
 
     /**
-     * The original version string before any modifications
+     * Used to match valid OSGi version based on section 3.2.5 of the OSGi specification
      */
-    private final String originalVersion;
+    private final static String OSGI_VERSION_REGEX = "(\\d+)(\\.\\d+(\\.\\d+([\\.][\\w\\-_]+)?)?)?";
 
-    /**
-     * The original unmodified major, minor, micro portion of the version string.
-     */
-    private String originalMMM;
+    private final static Pattern osgiPattern = Pattern.compile(OSGI_VERSION_REGEX);
 
-    private String majorVersion;
-
-    private String minorVersion;
-
-    private String microVersion;
-
-    /**
-     * The original unmodified version qualifier. Will be null if no qualifier is included.
-     */
-    private String originalQualifier;
-
-    /**
-     * The delimiter between the MMM version and the qualifier
-     */
-    private static final char DEFAULT_MMM_DELIMITER = OSGI_VERSION_DELIMITER;
-
-    /**
-     * The delimiter between the parts of the qualifier
-     */
-    private static final char DEFAULT_QUALIFIER_DELIMITER = '-';
-
-    /**
-     * The original delimiter between the MMM version and the qualifier.
-     */
-    private String qualifierStartDelimiter;
-
-    private String qualifierBase;
-
-    private String buildNumberDelimiter;
-
-    /**
-     * Numeric string at the end of the qualifier
-     */
-    private String buildNumber;
-
-    private String snapshotDelimiter;
-
-    /**
-     * The snapshot portion of the qualifier
-     */
-    private String snapshot;
-
-    /**
-     * Represents whether the major, minor, micro versions are valid integers. This will be false if the version string
-     * uses a property string like "${myVersion}-build-1" or if the version string starts with alpha chars like
-     * "GA-1-Beta". In these cases we can't parse the major, minor, micro versions, so we just leave the string intact.
-     */
-    private boolean numericVersion = true;
-
-    public Version( String version )
+    public static String getBuildNumber(String version)
     {
-        originalVersion = version;
-        logger.debug( "Parsing version: " + originalVersion );
-        parseVersion( originalVersion );
-        logger.debug( "Major: " + getMajorVersion() + ", Minor: " + getMinorVersion() + ",  Micro: " +
-            getMicroVersion() );
-        logger.debug( "Qualifier: " + getQualifier() + ", Base: " + getQualifierBase() + ", BuildNum: " +
-            getBuildNumber() );
+        Matcher qualifierMatcher = qualifierPattern.matcher( getQualifier( version ) );
+        if( qualifierMatcher.matches() && !isEmpty( qualifierMatcher.group( 4 ) ) )
+        {
+            return qualifierMatcher.group( 4 );
+        }
+        return EMPTY_STRING;
+    }
+
+    static String getMMM(String version)
+    {
+        Matcher versionMatcher = versionPattern.matcher( version );
+        if ( versionMatcher.matches() )
+        {
+            return versionMatcher.group( 1 );
+        }
+        return EMPTY_STRING;
     }
 
     /**
-     * Parse a version string into its component parts (major, minor, micro, qualifier). By default will split the
-     * String based on ".", "-", and "_".
+     * Get the major, minor, micro version in OSGi format
+     *
+     * @param version The version to parse
+     * @param fill Whether to fill the minor and micro versions with zeros if they are missing
+     * @return
+     */
+    static String getOsgiMMM(String version, boolean fill)
+    {
+        String mmm = getMMM( version );
+        Matcher mmmMatcher = mmmPattern.matcher( mmm );
+        if ( mmmMatcher.matches() )
+        {
+            String osgiMMM = mmmMatcher.group( 1 );
+            String minorVersion = mmmMatcher.group( 3 );
+            if ( !isEmpty( minorVersion ) )
+            {
+                osgiMMM += OSGI_VERSION_DELIMITER + minorVersion;
+            }
+            else if ( fill )
+            {
+                osgiMMM += OSGI_VERSION_DELIMITER + "0";
+            }
+            String microVersion = mmmMatcher.group( 5 );
+            if ( !isEmpty( microVersion ) )
+            {
+                osgiMMM += OSGI_VERSION_DELIMITER + microVersion;
+            }
+            else if ( fill )
+            {
+                osgiMMM += OSGI_VERSION_DELIMITER + "0";
+            }
+            return osgiMMM;
+        }
+        return EMPTY_STRING;
+    }
+
+    public static String getOsgiVersion(String version)
+    {
+        String qualifier = getQualifier( version );
+        if ( !isEmpty( qualifier ) )
+        {
+            qualifier = OSGI_VERSION_DELIMITER + qualifier.replace( OSGI_VERSION_DELIMITER, OSGI_QUALIFIER_DELIMITER );
+        }
+        String mmm = getOsgiMMM( version, !isEmpty( qualifier ) );
+        if ( isEmpty( mmm ) )
+        {
+            logger.warn( "Unable to parse version for OSGi: " + version );
+            return version;
+        }
+        return mmm + qualifier;
+    }
+
+    public static String getQualifier(String version)
+    {
+        Matcher versionMatcher = versionPattern.matcher( version );
+        if ( versionMatcher.matches() )
+        {
+            return versionMatcher.group( 9 );
+        }
+        return removeLeadingDelimiter( version );
+    }
+
+    public static String getQualifierBase(String version)
+    {
+        Matcher versionMatcher = versionPattern.matcher( version );
+        if ( versionMatcher.matches() )
+        {
+            return versionMatcher.group( 10 );
+        }
+        Matcher qualifierMatcher = qualifierPattern.matcher( version );
+        if ( qualifierMatcher.matches() )
+        {
+            return qualifierMatcher.group( 1 );
+        }
+        return removeLeadingDelimiter( version );
+    }
+
+    public static String getQualifierWithDelim(String version)
+    {
+        Matcher versionMatcher = versionPattern.matcher( version );
+        if ( versionMatcher.matches() )
+        {
+            return versionMatcher.group( 7 );
+        }
+        return version;
+    }
+
+    public static String getSnapshot( String version )
+    {
+        Matcher snapshotMatcher = snapshotPattern.matcher( version );
+        if ( snapshotMatcher.matches() )
+        {
+            return snapshotMatcher.group(4);
+        }
+        return EMPTY_STRING;
+    }
+
+    public static String getSnapshotWithDelim( String version )
+    {
+        Matcher snapshotMatcher = snapshotPattern.matcher( version );
+        if ( snapshotMatcher.matches() )
+        {
+            return snapshotMatcher.group(2);
+        }
+        return EMPTY_STRING;
+    }
+
+    public static boolean hasBuildNumber( String version )
+    {
+        return !isEmpty( getBuildNumber( version ) );
+    }
+
+    public static boolean hasQualifier( String version )
+    {
+        return !isEmpty( getQualifier( version ) );
+    }
+
+    public static boolean isEmpty( String string )
+    {
+        if ( string == null )
+        {
+            return true;
+        }
+        if ( string.trim().equals( EMPTY_STRING ) )
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isSnapshot( String version )
+    {
+        Matcher snapshotMatcher = snapshotPattern.matcher( version );
+        return snapshotMatcher.matches();
+    }
+
+    /**
+     * Checks if the string is a valid version according to section 3.2.5 of the OSGi specification
+     *
+     * @return true if the version is valid
+     */
+    public static boolean isValidOSGi(String version)
+    {
+        return osgiPattern.matcher( version ).matches();
+    }
+
+    /**
+     * Remove the build number (and associated delimiter) portion of the version string
      *
      * @param version
      * @return
      */
-    private void parseVersion( final String version )
+    public static String removeBuildNumber( String version )
+    {
+        Matcher qualifierMatcher = qualifierPattern.matcher( version );
+        if ( qualifierMatcher.matches() )
+        {
+            return qualifierMatcher.replaceFirst( "$1$5" );
+        }
+        return version;
+    }
+
+    /**
+     * Remove the snapshot (and associated delimiter) portion of the version string
+     *
+     * @param version
+     * @return
+     */
+    public static String removeSnapshot( String version )
     {
         Matcher snapshotMatcher = snapshotPattern.matcher( version );
-        snapshotMatcher.matches();
-        final String versionWithoutSnapshot = snapshotMatcher.group( 1 );
-        snapshotDelimiter = snapshotMatcher.group( 3 );
-        snapshot = snapshotMatcher.group( 4 );
-
-        Matcher versionMatcher = versionPattern.matcher( versionWithoutSnapshot );
-        if ( !versionMatcher.matches() )
+        if ( snapshotMatcher.matches() )
         {
-            return;
+            return snapshotMatcher.group(1);
         }
-        originalMMM = versionMatcher.group( 1 );
-        qualifierStartDelimiter = versionMatcher.group( 7 );
-        originalQualifier = versionMatcher.group( 8 );
+        return version;
+    }
 
-        parseMMM( originalMMM );
-        parseQualifier( originalQualifier );
+    static boolean hasLeadingDelimiter( String versionPart )
+    {
+        if ( versionPart.length() < 1 )
+        {
+            return false;
+        }
+        return versionStringDelimiters.contains( versionPart.charAt( 0 ) );
     }
 
     /**
-     * Parse the mmm (major, minor, micro) portions of the version string
+     * Remove any leading delimiters from the partial version string
      *
-     * @param mmm The numeric portion of the version string before the qualifier
+     * @param versionPart
+     * @return
      */
-    private void parseMMM( String mmm )
+    static String removeLeadingDelimiter(String versionPart )
     {
-        if ( isEmpty( mmm ) )
-        {
-            numericVersion = false;
-            return;
-        }
-
-        Matcher mmmMatcher = mmmPattern.matcher( mmm );
-        mmmMatcher.matches();
-
-        majorVersion = mmmMatcher.group( 1 );
-        String minor = mmmMatcher.group( 3 );
-        if ( !isEmpty( minor ) )
-        {
-            minorVersion = minor;
-        }
-        String micro = mmmMatcher.group( 5 );
-        if ( !isEmpty( micro ) )
-        {
-            microVersion = micro;
-        }
+        return versionPart.replaceAll(LEADING_DELIMITER_REGEX, "");
     }
 
     /**
-     * Parses the qualifier into the format &gt;qualifierBase&lt;-&gt;buildnumber&lt;-&gt;snapshot&lt;.
-     *
-     * @param qualifier
+     * Prepends the given delimiter only if the versionPart does not already start with a delimiter
      */
-    private void parseQualifier( String qualifier )
+    private static String prependDelimiter( String versionPart, String delimiter )
     {
-        if ( isEmpty( qualifier ) )
+        if ( hasLeadingDelimiter( versionPart ) )
         {
-            return;
+            return versionPart;
         }
-
-        Matcher qualifierMatcher = qualifierPattern.matcher( qualifier );
-        qualifierMatcher.matches();
-
-        qualifierBase = qualifierMatcher.group( 1 );
-        buildNumberDelimiter = qualifierMatcher.group( 3 );
-        if ( buildNumberDelimiter == null )
-        {
-            buildNumberDelimiter = "";
-        }
-        buildNumber = qualifierMatcher.group( 4 );
-        if ( buildNumber == null )
-        {
-            buildNumberDelimiter = Character.toString( DEFAULT_QUALIFIER_DELIMITER );
-        }
+        return delimiter + versionPart;
     }
 
     /**
      * Remove any delimiters from the end of the string
-     *
+     * //TODO: maybe remove this method
      * @param partialVersionString
      * @return
      */
@@ -248,26 +343,13 @@ public class Version
         return partialVersionString;
     }
 
-    private static boolean isEmpty( String string )
-    {
-        if ( string == null )
-        {
-            return true;
-        }
-        if ( string.trim().equals( "" ) )
-        {
-            return true;
-        }
-        return false;
-    }
-
     /**
      * Check if all the characters in the string are digits
      *
      * @param str a string to check
      * @return whether all the characters in the string are digits
      */
-    public static boolean isNumeric( String str )
+    static boolean isNumeric( String str )
     {
         for ( char c : str.toCharArray() )
         {
@@ -278,231 +360,6 @@ public class Version
     }
 
     /**
-     * Checks if the original version string is a valid OSGi version.
-     *
-     * @return true if the version is valid
-     */
-    public boolean isValidOSGi()
-    {
-        Matcher osgiMatcher = osgiPattern.matcher( originalVersion );
-        return osgiMatcher.matches();
-    }
-
-    public String getMajorVersion()
-    {
-        if ( isEmpty( majorVersion) )
-        {
-            majorVersion = "0";
-        }
-        return majorVersion;
-    }
-
-    /**
-     * Assumed to be "0" if no minor version is specified in the string
-     *
-     * @return the minor version
-     */
-    public String getMinorVersion()
-    {
-        if ( isEmpty( minorVersion ) )
-        {
-            minorVersion = "0";
-        }
-        return minorVersion;
-    }
-
-    /**
-     * Assumed to be "0" if no micro version is specified in the string
-     *
-     * @return the micro version
-     */
-    public String getMicroVersion()
-    {
-        if ( isEmpty( microVersion ) )
-        {
-            microVersion = "0";
-        }
-        return microVersion;
-    }
-
-    /**
-     * Get the original version string that was used to create this version object.
-     *
-     * @return the original version string
-     */
-    public String getOriginalVersion()
-    {
-        return originalVersion;
-    }
-
-    /**
-     * Get original unmodified major, minor, micro portion of the version string
-     *
-     * @return the original major/minor/micro version.
-     */
-    public String getOriginalMMM()
-    {
-        if ( originalMMM == null )
-        {
-            originalMMM = "";
-        }
-        return originalMMM;
-    }
-
-    /**
-     * Generate the qualifier by combining the qualifierBase, qualifierSuffix, and build number
-     *
-     * @return The qualifier part of the version string (an empty string if there is no qualifier)
-     */
-    public String getQualifier()
-    {
-        StringBuilder qualifier = new StringBuilder();
-        qualifier.append( getQualifierBaseAndBuildNum() );
-
-        if ( isSnapshot() )
-        {
-            if ( qualifier.length() > 0 )
-            {
-                qualifier.append( DEFAULT_QUALIFIER_DELIMITER );
-            }
-            qualifier.append( this.snapshot );
-        }
-
-        return qualifier.toString();
-    }
-
-    public String getQualifierBase()
-    {
-        if ( qualifierBase == null )
-        {
-            qualifierBase = "";
-        }
-        return qualifierBase;
-    }
-
-    public String getQualifierBaseAndBuildNum()
-    {
-        StringBuilder qualBaseAndNum = new StringBuilder( getQualifierBase() );
-        if ( !isEmpty( getBuildNumber() ) )
-        {
-            if ( qualBaseAndNum.length() > 0 )
-            {
-                qualBaseAndNum.append( getBuildNumberDelimiter() );
-            }
-            qualBaseAndNum.append( getBuildNumber() );
-        }
-        return qualBaseAndNum.toString();
-    }
-
-    public String getVersionString()
-    {
-        if ( isEmpty( getQualifier() ) )
-        {
-            return originalVersion;
-        }
-        if ( isEmpty( originalMMM ) )
-        {
-            return getQualifier();
-        }
-
-        StringBuilder versionString = new StringBuilder();
-        versionString.append( originalMMM );
-        if ( isEmpty( qualifierStartDelimiter ) )
-        {
-            versionString.append( DEFAULT_MMM_DELIMITER );
-        }
-        else
-        {
-            versionString.append( qualifierStartDelimiter  );
-        }
-        versionString.append( getQualifier() );
-        return versionString.toString();
-    }
-
-    public String getOSGiVersionString()
-    {
-        if ( isValidOSGi() && !hasQualifier() )
-        {
-            return originalVersion;
-        }
-        StringBuilder osgiVersion = new StringBuilder();
-        if ( numericVersion )
-        {
-            osgiVersion.append( getThreePartMMM() );
-        }
-        if ( !isEmpty( getQualifier() ) )
-        {
-            if ( numericVersion )
-            {
-                osgiVersion.append( OSGI_VERSION_DELIMITER );
-            }
-            osgiVersion.append( getOSGiQualifier() );
-        }
-        return osgiVersion.toString();
-
-    }
-
-    /**
-     * Get the major, minor, micro version string and use zeros if the minor or micro were not set in the original
-     * version
-     *
-     * @return
-     */
-    private String getThreePartMMM()
-    {
-        StringBuilder mmm = new StringBuilder();
-        mmm.append( getMajorVersion() );
-        mmm.append( OSGI_VERSION_DELIMITER );
-        mmm.append( getMinorVersion() );
-        mmm.append( OSGI_VERSION_DELIMITER );
-        mmm.append( getMicroVersion() );
-        return mmm.toString();
-    }
-
-    /**
-     * Replaces "." delimiters with a "-";
-     *
-     * @return
-     */
-    private String getOSGiQualifier()
-    {
-        if ( getQualifier() == null )
-        {
-            return null;
-        }
-        return getQualifier().replace( '.', '-' );
-    }
-
-    public boolean isSnapshot()
-    {
-        return SNAPSHOT_SUFFIX.equalsIgnoreCase( this.snapshot );
-    }
-
-    public String getBuildNumber()
-    {
-        return buildNumber;
-    }
-
-    public String getBuildNumberDelimiter()
-    {
-        if ( buildNumberDelimiter == null )
-        {
-            buildNumberDelimiter = "";
-        }
-        return buildNumberDelimiter;
-    }
-
-    public boolean hasBuildNumber()
-    {
-        return !isEmpty( getBuildNumber() );
-    }
-
-    public boolean hasQualifier()
-    {
-        return !isEmpty( getQualifier() );
-    }
-
-    /**
      * Appends the given qualifier suffix.  Attempts to match the given qualifier suffix to the current suffix
      * to avoid duplicates like "1.0-beta-beta.  If the suffix matches the existing one, does nothing.
      *
@@ -510,84 +367,81 @@ public class Version
      *            include a build number, for example "foo-1", which will automatically be set as the build number for
      *            this version.
      */
-    public void appendQualifierSuffix( String suffix )
+    public static String appendQualifierSuffix( final String version, final String suffix )
     {
-        logger.debug( "Applying suffix: " + suffix + " to version " + getVersionString() );
-        if ( suffix == null )
+        logger.debug( "Applying suffix: " + suffix + " to version " + version );
+
+        if ( isEmpty( suffix ) )
         {
-            return;
+            return version;
         }
 
-        // Remove snapshot portion first to make parsing simpler
-        Matcher snapshotMatcher = snapshotPattern.matcher( suffix );
-        snapshotMatcher.matches();
-        final String suffixWithoutSnapshot = snapshotMatcher.group( 1 );
-        final String suffixSnapshotDelimiter = snapshotMatcher.group( 3 );
-        final String suffixSnapshot = snapshotMatcher.group( 4 );
-        if ( !isEmpty( suffixSnapshot ) )
+        if ( isEmpty( getQualifier( version ) ) )
         {
-            this.snapshotDelimiter = suffixSnapshotDelimiter;
-            this.snapshot = suffixSnapshot;
+            return version + prependDelimiter( suffix, DEFAULT_DELIMITER);
         }
 
-        // Handle the non-snapshot portion of the new suffix
-        Matcher suffixMatcher = qualifierPattern.matcher( suffixWithoutSnapshot );
-        if ( !suffixMatcher.matches() )
+        Matcher suffixMatcher = createSuffixMatcher( version, suffix );
+        if ( suffixMatcher.matches() )
         {
-            return;
+            return version;
         }
 
-        String suffixBase = suffixMatcher.group( 1 );
-        String suffixBuildNumberDelimiter = suffixMatcher.group( 3 );
-        String suffixBuildNumber = suffixMatcher.group( 4 );
+        final String suffixWoSnapshot = removeSnapshot( suffix );
+        final String suffixBuildNumber = getBuildNumber( suffix );
+        final String suffixWoBuildNumber = removeBuildNumber( suffixWoSnapshot );
+        final String suffixWoBuildNumDelim = removeLeadingDelimiter( suffixWoBuildNumber );
 
-        String suffixBaseNoDelim = this.removeLastDelimiters( suffixBase );
-        String suffixMatchRegex = "(.*?)(" + Pattern.quote( suffixBaseNoDelim ) + ")(" + DELIMITER_REGEX + "?)";
-
-        String oldQualifierBase = getQualifierBase();
-        String oldQualifierBaseAndNum = getQualifierBaseAndBuildNum();
-        if ( isEmpty( oldQualifierBaseAndNum ) )
-        {
-            if ( suffixBase.length() > 0 && versionStringDelimiters.contains( suffixBase.charAt( 0 ) ) )
+        Matcher suffixWoDelimMatcher = createSuffixMatcher( version, suffixWoBuildNumDelim );
+        if (suffixWoDelimMatcher.matches()) {
+            String newVersion = suffixWoDelimMatcher.replaceFirst("$1$2" + suffixWoBuildNumber + "$4$7");
+            if ( hasLeadingDelimiter( suffix ) )
             {
-                qualifierStartDelimiter = Character.toString( suffixBase.charAt( 0 ) );
-                suffixBase = suffixBase.substring( 1 );
+                newVersion = suffixWoDelimMatcher.replaceFirst("$1" + suffixWoBuildNumber + "$4$7");
             }
-            qualifierBase = suffixBase;
+            if ( !isEmpty( suffixBuildNumber ) )
+            {
+                newVersion = setBuildNumber( newVersion, suffixBuildNumber );
+            }
+            if ( isSnapshot( suffix ) )
+            {
+                newVersion = setSnapshot( newVersion, true );
+            }
+            return newVersion;
         }
-        // Check if the new suffix does not match the end of the existing qualifier
-        else if ( !Pattern.matches( suffixMatchRegex, oldQualifierBase ) )
+
+        Matcher qualifierMatcher = qualifierPattern.matcher( version );
+        if ( qualifierMatcher.matches() )
         {
-            // If the suffix doesn't match, and there is an existing build number
-            // the old build number becomes part of the qualifier base
-            // e.g. "1.2.0.Beta-1" + "foo-2" = "1.2.0.Beta-1-foo-2"
-            StringBuilder newQualifierBase = new StringBuilder( oldQualifierBaseAndNum );
-            buildNumber = null;
-
-            if ( newQualifierBase.length() > 0 &&
-                    !versionStringDelimiters.contains( newQualifierBase.charAt( newQualifierBase.length() - 1 ) ) )
+            if ( hasLeadingDelimiter( suffixWoSnapshot ) )
             {
-                newQualifierBase.append( DEFAULT_QUALIFIER_DELIMITER );
+                String newVersion = qualifierMatcher.replaceFirst( "$1$3$4" + suffixWoSnapshot + "$5");
+                if ( isSnapshot( suffix ) )
+                {
+                    newVersion = Version.setSnapshot( newVersion, true );
+                }
+                return newVersion;
             }
-            newQualifierBase.append(suffixBase);
-            qualifierBase = newQualifierBase.toString();
-            buildNumberDelimiter = suffixBuildNumberDelimiter;
+            String delimiter = DEFAULT_QUALIFIER_DELIMITER;
+            if ( isEmpty( getQualifierBase( version ) ) )
+            {
+                delimiter = DEFAULT_DELIMITER;
+            }
+            String newVersion = qualifierMatcher.replaceFirst( "$1$3$4" + delimiter + suffixWoSnapshot + "$5");
+            if ( isSnapshot( suffix ) )
+            {
+                newVersion = Version.setSnapshot( newVersion, true );
+            }
+            return newVersion;
         }
+        return version;
+    }
 
-        if ( !isEmpty( suffixBuildNumber ) )
-        {
-            if ( suffixBuildNumberDelimiter == null )
-            {
-                buildNumberDelimiter = "";
-            }
-            else
-            {
-                buildNumberDelimiter = suffixBuildNumberDelimiter;
-            }
-            buildNumber = suffixBuildNumber;
-        }
-
-        logger.debug( "New version string: " + getVersionString() );
+    private static Matcher createSuffixMatcher( String version, String suffix )
+    {
+        final String SUFFIX_REGEX = "(.*?)(" + DELIMITER_REGEX + ")?(" + suffix + ")(("
+                + DELIMITER_REGEX + ")?(\\d+))?((" + DELIMITER_REGEX + ")?((?i:" + SNAPSHOT_SUFFIX + ")))?$";
+        return Pattern.compile( SUFFIX_REGEX ).matcher( version );
     }
 
     /**
@@ -596,31 +450,52 @@ public class Version
      *
      * @param buildNumber to append to the qualifier.
      */
-    public void setBuildNumber( String buildNumber )
+    public static String setBuildNumber( String version, String buildNumber )
     {
-        if ( buildNumberDelimiter == null ) {
-            buildNumberDelimiter = Character.toString( DEFAULT_QUALIFIER_DELIMITER );
-        }
-        if ( buildNumber == null || isNumeric( buildNumber ) )
+        if ( isEmpty( buildNumber ) )
         {
-            this.buildNumber = buildNumber;
+            buildNumber = EMPTY_STRING;
         }
+        if ( isEmpty( getQualifier( version ) ) )
+        {
+            return version + DEFAULT_DELIMITER + buildNumber;
+        }
+        Matcher qualifierMatcher = qualifierPattern.matcher( version );
+        if ( qualifierMatcher.matches() )
+        {
+            if ( isEmpty( qualifierMatcher.group( 2 ) ) )
+            {
+                buildNumber = prependDelimiter( buildNumber, DEFAULT_QUALIFIER_DELIMITER );
+            }
+            return qualifierMatcher.replaceFirst( "$1$3" + buildNumber + "$5" );
+        }
+        return version;
     }
 
     /**
-     * Sets the snapshot to "SNAPSHOT" if true, otherwise sets to null
+     * Appends the "SNAPSHOT" suffix to this version if not already present
      *
-     * @param snapshot whether to append SNAPSHOT or not.
+     * @param version the version to modify.
+     * @param snapshot set to true if the version should be a snapshot, false otherwise
+     * @return The updated version string
      */
-    public void setSnapshot( boolean snapshot )
+    public static String setSnapshot( String version, boolean snapshot )
     {
-        if ( snapshot )
+        if ( isEmpty( version ) )
         {
-            this.snapshot = SNAPSHOT_SUFFIX;
+            return EMPTY_STRING;
+        }
+        if ( isSnapshot( version ) == snapshot )
+        {
+            return version;
+        }
+        else if ( snapshot )
+        {
+            return (version + DEFAULT_QUALIFIER_DELIMITER + SNAPSHOT_SUFFIX);
         }
         else
         {
-            this.snapshot = null;
+            return removeSnapshot( version );
         }
     }
 
@@ -632,19 +507,26 @@ public class Version
      * @param versionSet a collection of versions to compare to.
      * @return the highest build number, or 0 if no matching build numbers are found.
      */
-    public static int findHighestMatchingBuildNumber( Version version, Set<String> versionSet )
+    public static int findHighestMatchingBuildNumber(String version, Set<String> versionSet )
     {
         int highestBuildNum = 0;
+
+        String qualifier = getQualifier( version );
+        Matcher qualifierMatcher = qualifierPattern.matcher( qualifier );
+        if ( qualifierMatcher.matches() )
+        {
+            qualifier = removeLeadingDelimiter( qualifierMatcher.group( 1 ) );
+        }
 
         // Build version pattern regex, matches something like "<mmm>.<qualifier>.<buildnum>".
         StringBuilder versionPatternBuf = new StringBuilder();
         versionPatternBuf.append( '(' )
-                .append( Pattern.quote( version.getOriginalMMM() ) ).append('(').append( DELIMITER_REGEX ).append("0)*") // Match zeros appended to a major only version
+                .append( Pattern.quote( getMMM( version ) ) ).append('(').append( DELIMITER_REGEX ).append("0)*") // Match zeros appended to a major only version
                 .append( ")?" )
                 .append( DELIMITER_REGEX );
-        if ( !isEmpty( version.getQualifierBase() ) )
+        if ( !isEmpty( qualifier ) )
         {
-            versionPatternBuf.append( Pattern.quote( version.getQualifierBase() ) );
+            versionPatternBuf.append( Pattern.quote( qualifier ) );
             versionPatternBuf.append( DELIMITER_REGEX );
         }
         versionPatternBuf.append( "(\\d+)" );
@@ -676,23 +558,20 @@ public class Version
      *
      * @return the build number as an integer.
      */
-    public int getIntegerBuildNumber()
+    public static int getIntegerBuildNumber( String version )
     {
-        if ( this.isEmpty( buildNumber ) )
+        String buildNumber = getBuildNumber( version );
+        if ( isEmpty( buildNumber ) )
         {
             return 0;
         }
-        return Integer.parseInt( buildNumber );
+        try
+        {
+            return Integer.parseInt( buildNumber );
+        }
+        catch(NumberFormatException e) {
+            return 0;
+        }
     }
 
-    @Override
-    public String toString()
-    {
-        StringBuilder buffer = new StringBuilder();
-        buffer.append( "Version: " );
-        buffer.append( getVersionString() );
-        buffer.append( ", OSGi Version: " );
-        buffer.append( getOSGiVersionString() );
-        return buffer.toString();
-    }
 }

--- a/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
+++ b/core/src/main/java/org/commonjava/maven/ext/manip/util/PropertiesUtils.java
@@ -240,13 +240,13 @@ public final class PropertiesUtils
         String newVersion = newValue;
         String suffix = getSuffix( session );
 
-        Version v = new Version( oldValue );
+        String v = oldValue ;
         if ( !vState.preserveSnapshot() )
         {
-            v.setSnapshot( false );
+            v = Version.removeSnapshot( v );
         }
 
-        String osgiVersion = v.getOSGiVersionString();
+        String osgiVersion = Version.getOsgiVersion( v );
 
         // If we have been configured to ignore the suffix (e.g. rebuild-n) then, assuming that
         // the oldValue actually contains the suffix process it.
@@ -264,8 +264,8 @@ public final class PropertiesUtils
             {
                 String oldValueCache = oldValue;
                 oldValue = oldValue.substring( 0, oldValue.indexOf( suffix ) - 1 );
-                v = new Version( oldValue );
-                osgiVersion = v.getOSGiVersionString();
+                v = oldValue;
+                osgiVersion = Version.getOsgiVersion( v );
                 logger.debug( "Updating version to {} and for oldValue {} with newValue {} ", v, oldValueCache, newValue );
 
             }
@@ -277,10 +277,10 @@ public final class PropertiesUtils
 
         // We only need to dummy up and add a suffix if there is no qualifier. This allows us
         // to work out the OSGi version.
-        if ( suffix != null && !v.hasQualifier() )
+        if ( suffix != null && !Version.hasQualifier( v ) )
         {
-            v.appendQualifierSuffix( suffix );
-            osgiVersion = v.getOSGiVersionString();
+            v = Version.appendQualifierSuffix( v, suffix );
+            osgiVersion = Version.getOsgiVersion( v );
             osgiVersion = osgiVersion.substring( 0, osgiVersion.indexOf( suffix ) - 1 );
         }
         if ( suffix != null && newValue.contains( suffix ) )

--- a/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
@@ -46,6 +46,8 @@ public class VersionTest
         assertThat( Version.appendQualifierSuffix( "1.2-jboss-1", "jboss-2" ), equalTo( "1.2-jboss-2") );
         assertThat( Version.appendQualifierSuffix( "1.2-jboss-1", ".jboss-2" ), equalTo( "1.2.jboss-2") );
         assertThat( Version.appendQualifierSuffix( "1.1-SNAPSHOT", ".test_jdk7-SNAPSHOT" ), equalTo( "1.1.test_jdk7-SNAPSHOT") );
+        assertThat( Version.appendQualifierSuffix( "1.1.beta-2", "-beta-1" ), equalTo( "1.1-beta-1") );
+        assertThat( Version.appendQualifierSuffix( "1.1.beta-2", "-foo-1" ), equalTo( "1.1.beta-2-foo-1") );
     }
 
     @Test

--- a/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
@@ -49,6 +49,15 @@ public class VersionTest
     }
 
     @Test
+    public void testAppendQualifierSuffix_WithProperty()
+    {
+        assertThat( Version.appendQualifierSuffix( "${project.version}", "foo" ), equalTo( "${project.version}-foo") );
+        assertThat( Version.appendQualifierSuffix( "1.0.${micro}", ".foo" ), equalTo( "1.0.${micro}.foo") );
+        assertThat( Version.setBuildNumber( "${project.version}", "10" ), equalTo( "${project.version}-10") );
+        assertThat( Version.setBuildNumber( "${project.version}-foo", "10" ), equalTo( "${project.version}-foo-10") );
+    }
+
+    @Test
     public void testAppendQualifierSuffix_MulitpleTimes()
     {
 
@@ -195,6 +204,14 @@ public class VersionTest
     }
 
     @Test
+    public void testGetQualifierBase() {
+        assertThat(Version.getQualifierBase("1.0-SNAPSHOT"), equalTo(""));
+        assertThat(Version.getQualifierBase("1.0.0.Beta1"), equalTo("Beta"));
+        assertThat(Version.getQualifierBase("1.0.0.jboss-test-SNAPSHOT"), equalTo("jboss-test"));
+        assertThat(Version.getQualifierBase("${project.version}-test-1"), equalTo("${project.version}-test"));
+    }
+
+    @Test
     public void testGetSnapshot()
     {
         assertThat( Version.getSnapshot( "1.0-SNAPSHOT" ), equalTo( "SNAPSHOT" ) );
@@ -268,6 +285,10 @@ public class VersionTest
     {
         assertThat( Version.setSnapshot( "1.0-SNAPSHOT", true ), equalTo( "1.0-SNAPSHOT" ) );
         assertThat( Version.setSnapshot( "1.0-SNAPSHOT", false ), equalTo( "1.0" ) );
+        assertThat( Version.setSnapshot( "1.1", true ), equalTo( "1.1-SNAPSHOT" ) );
+        assertThat( Version.setSnapshot( "1.1", false ), equalTo( "1.1" ) );
+        assertThat( Version.setSnapshot( "1.2.jboss-1", true ), equalTo( "1.2.jboss-1-SNAPSHOT" ) );
+        assertThat( Version.setSnapshot( "1.2.jboss-1", false ), equalTo( "1.2.jboss-1" ) );
         assertThat( Version.setSnapshot( "1.0.0.Beta1_snapshot", true ), equalTo( "1.0.0.Beta1_snapshot" ) );
         assertThat( Version.setSnapshot( "1.0.0.Beta1_snapshot", false ), equalTo( "1.0.0.Beta1" ) );
         assertThat( Version.setSnapshot( "1.snaPsHot", true ), equalTo( "1.snaPsHot" ) );
@@ -279,7 +300,7 @@ public class VersionTest
     }
 
     @Test
-    public void testStripLeadingDelimiters()
+    public void testRemoveLeadingDelimiters()
     {
         assertThat( Version.removeLeadingDelimiter( ".1.2" ), equalTo( "1.2" ) );
         assertThat( Version.removeLeadingDelimiter( "_Beta1" ), equalTo( "Beta1" ) );

--- a/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -306,6 +306,5 @@ public class VersionTest
         assertFalse( Version.isValidOSGi("1beta") );
         assertFalse( Version.isValidOSGi("beta1") );
     }
-
 
 }

--- a/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,335 +20,292 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.commonjava.maven.ext.manip.impl.Version.findHighestMatchingBuildNumber;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
 
 public class VersionTest
 {
 
     @Test
-    public void testParseVersion()
-        throws Exception
+    public void testAppendQualifierSuffix()
     {
-        Version version = new Version("1.2.beta2");
-        assertThat( version.getMajorVersion(), equalTo( "1" ) );
-        assertThat( version.getMinorVersion(), equalTo( "2" ) );
-        assertThat( version.getMicroVersion(), equalTo( "0" ) );
-        assertThat( version.getQualifier(), equalTo( "beta2" ) );
-
-        version = new Version("1");
-        assertThat( version.getMajorVersion(), equalTo( "1" ) );
-        assertThat( version.getMinorVersion(), equalTo( "0" ) );
-        assertThat( version.getMicroVersion(), equalTo( "0" ) );
-        assertThat( version.getQualifier(), equalTo( "" ) );
-
-        version = new Version("1beta1");
-        assertThat( version.getMajorVersion(), equalTo( "1" ) );
-        assertThat( version.getMinorVersion(), equalTo( "0" ) );
-        assertThat( version.getMicroVersion(), equalTo( "0" ) );
-        assertThat( version.getQualifier(), equalTo( "beta1" ) );
-
-        version = new Version("1-0-3.4-beta2");
-        assertThat( version.getMajorVersion(), equalTo( "1" ) );
-        assertThat( version.getMinorVersion(), equalTo( "0" ) );
-        assertThat( version.getMicroVersion(), equalTo( "3" ) );
-        assertThat( version.getQualifier(), equalTo( "4-beta2" ) );
-
-        version = new Version("11-01-beta2_SNAPSHOT_HELLO-1");
-        assertThat( version.getMajorVersion(), equalTo( "11" ) );
-        assertThat( version.getMinorVersion(), equalTo( "01" ) );
-        assertThat( version.getMicroVersion(), equalTo( "0" ) );
-        assertThat( version.getQualifier(), equalTo( "beta2_SNAPSHOT_HELLO-1" ) );
-
-        version = new Version("1.2.3.4.Final-X");
-        assertThat( version.getMajorVersion(), equalTo( "1" ) );
-        assertThat( version.getMinorVersion(), equalTo( "2" ) );
-        assertThat( version.getMicroVersion(), equalTo( "3" ) );
-        assertThat( version.getQualifier(), equalTo( "4.Final-X" ) );
+        assertThat( Version.appendQualifierSuffix( "1.0", "foo" ), equalTo( "1.0.foo") );
+        assertThat( Version.appendQualifierSuffix( "1.0.0.Beta1", "foo" ), equalTo( "1.0.0.Beta1-foo") );
+        assertThat( Version.appendQualifierSuffix( "1.0_Betafoo", "foo" ), equalTo( "1.0_Betafoo") );
+        assertThat( Version.appendQualifierSuffix( "1.0_fooBeta", "foo" ), equalTo( "1.0_fooBeta-foo") );
+        assertThat( Version.appendQualifierSuffix( "1.0", "-foo" ), equalTo( "1.0-foo") );
+        assertThat( Version.appendQualifierSuffix( "1.0.0.Beta1", "_foo" ), equalTo( "1.0.0.Beta1_foo") );
+        assertThat( Version.appendQualifierSuffix( "1.0_Betafoo", "-foo" ), equalTo( "1.0_Beta-foo") );
+        assertThat( Version.appendQualifierSuffix( "1.0_Beta.foo", "-foo" ), equalTo( "1.0_Beta-foo") );
+        assertThat( Version.appendQualifierSuffix( "jboss-1-GA", "jboss" ), equalTo( "jboss-1-GA-jboss") );
+        assertThat( Version.appendQualifierSuffix( "1.2", "jboss-1-SNAPSHOT" ), equalTo( "1.2.jboss-1-SNAPSHOT") );
+        assertThat( Version.appendQualifierSuffix( "1.2-SNAPSHOT", "jboss1" ), equalTo( "1.2.jboss1-SNAPSHOT") );
+        assertThat( Version.appendQualifierSuffix( "1.2-jboss-1", "jboss-2" ), equalTo( "1.2-jboss-2") );
+        assertThat( Version.appendQualifierSuffix( "1.2-jboss-1", ".jboss-2" ), equalTo( "1.2.jboss-2") );
+        assertThat( Version.appendQualifierSuffix( "1.1-SNAPSHOT", ".test_jdk7-SNAPSHOT" ), equalTo( "1.1.test_jdk7-SNAPSHOT") );
     }
 
     @Test
-    public void testGetOsgiVersion()
-        throws Exception
+    public void testAppendQualifierSuffix_MulitpleTimes()
     {
-        Version version = new Version("1.2.beta2");
-        assertThat( version.isValidOSGi(), equalTo( false ) );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.beta2" ) );
 
-        version = new Version("1.2");
-        assertThat( version.isValidOSGi(), equalTo( true ) );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2" ) );
+        String version = "1.2.0";
+        version = Version.appendQualifierSuffix( version, "jboss-1" );
+        version = Version.appendQualifierSuffix( version, "foo" );
+        assertThat( version, equalTo( "1.2.0.jboss-1-foo" ) );
 
-        version = new Version("1");
-        assertThat( version.isValidOSGi(), equalTo( true ) );
-        assertThat( version.getOSGiVersionString(), equalTo( "1" ) );
-
-        version = new Version("2.6");
-        assertThat( version.isValidOSGi(), equalTo( true ) );
-        assertThat( version.getOSGiVersionString(), equalTo( "2.6" ) );
-
-        version = new Version("2.6");
-        version.appendQualifierSuffix( "rebuild-1" );
-        assertThat( version.isValidOSGi(), equalTo( true ) );
-        assertThat( version.getOSGiVersionString(), equalTo( "2.6.0.rebuild-1" ) );
-
-        version = new Version("12.1.100");
-        assertThat( version.isValidOSGi(), equalTo( true ) );
-        assertThat( version.getOSGiVersionString(), equalTo( "12.1.100" ) );
-
-        version = new Version("1beta1");
-        assertThat( version.isValidOSGi(), equalTo( false ) );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.0.0.beta1" ) );
-
-        version = new Version("1-0-3.4-beta2.1");
-        assertThat( version.isValidOSGi(), equalTo( false ) );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.0.3.4-beta2-1" ) );
-
-        version = new Version("10.0.54.beta-2_3");
-        assertThat( version.isValidOSGi(), equalTo( true ) );
-        assertThat( version.getOSGiVersionString(), equalTo( "10.0.54.beta-2_3" ) );
-
+        version = "1.2";
+        version = Version.appendQualifierSuffix( version, "jboss-1" );
+        version = Version.appendQualifierSuffix( version, "jboss-2" );
+        version = Version.getOsgiVersion( version );
+        assertThat( version, equalTo( "1.2.0.jboss-2" ) );
     }
 
     @Test
-    public void testGetBuildNumber()
-        throws Exception
-    {
-        Version version = new Version("1.2");
-        assertThat( version.getBuildNumber(), equalTo( null ) );
-
-        version = new Version("1.2beta11");
-        assertThat( version.getBuildNumber(), equalTo( "11" ) );
-
-        version = new Version("1.2.0.jboss-9");
-        assertThat( version.getBuildNumber(), equalTo( "9" ) );
-
-        version = new Version("1.2.3.5");
-        assertThat( version.getBuildNumber(), equalTo( "5" ) );
-
-        version = new Version("1.2-SNAPSHOT");
-        assertThat( version.getBuildNumber(), equalTo( null ) );
-
-        version = new Version("1.2-jboss");
-        assertThat( version.getBuildNumber(), equalTo( null ) );
-    }
-
-    @Test
-    public void testSetQualifierSuffix_getVersion()
-        throws Exception
-    {
-        Version version = new Version("1.2");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getVersionString(), equalTo( "1.2.jboss" ) );
-
-        version = new Version("1.2beta11");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getVersionString(), equalTo( "1.2.beta11-jboss" ) );
-
-        version = new Version("1.2.GA");
-        version.appendQualifierSuffix( "foo" );
-        assertThat( version.getVersionString(), equalTo( "1.2.GA-foo" ) );
-
-        version = new Version("foo-bar-bad");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getVersionString(), equalTo( "foo-bar-bad-jboss" ) );
-
-        version = new Version("1.2");
-        version.appendQualifierSuffix( "-SNAPSHOT" );
-        assertThat( version.getVersionString(), equalTo( "1.2.SNAPSHOT" ) );
-
-        version = new Version("1.2");
-        version.appendQualifierSuffix( "jboss-1-SNAPSHOT" );
-        assertThat( version.getVersionString(), equalTo( "1.2.jboss-1-SNAPSHOT" ) );
-
-        version = new Version("1.2");
-        version.appendQualifierSuffix( "jboss1" );
-        version.setSnapshot(true);
-        assertThat( version.getVersionString(), equalTo( "1.2.jboss1-SNAPSHOT" ) );
-
-        version = new Version("1.2-SNAPSHOT");
-        version.appendQualifierSuffix( "jboss1" );
-        version.setSnapshot(false);
-        assertThat( version.getVersionString(), equalTo( "1.2.jboss1" ) );
-
-        version = new Version("1.2-SNAPSHOT");
-        version.appendQualifierSuffix( "jboss1" );
-        version.setSnapshot(true);
-        assertThat( version.getVersionString(), equalTo( "1.2.jboss1-SNAPSHOT" ) );
-
-        version = new Version("1.2");
-        version.appendQualifierSuffix( "-jboss1" );
-        assertThat( version.getVersionString(), equalTo( "1.2-jboss1" ) );
-}
-    
-    @Test
-    public void testSetQualifierSuffix_getOSGiVersion()
-        throws Exception
-    {
-
-        Version version = new Version("jboss-1-GA");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getVersionString(), equalTo( "jboss-1-GA-jboss" ) );
-
-        version = new Version("1.2");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.jboss" ) );
-
-        version = new Version("1.2beta11");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.beta11-jboss" ) );
-
-        version = new Version("1.2.0.jboss-9");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.jboss-9" ) );
-
-        version = new Version("1.2.3.5");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.3.5-jboss" ) );
-
-        version = new Version("1.2-SNAPSHOT");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.jboss-SNAPSHOT" ) );
-
-        version = new Version("1.2-jboss-9-foo");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.jboss-9-foo-jboss" ) );
-
-        version = new Version("1.2.1.Final-jboss-8");
-        version.appendQualifierSuffix( "jboss" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.1.Final-jboss-8" ) );
-
-        version = new Version("1.2.1.Final");
-        version.appendQualifierSuffix( "jboss-1" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.1.Final-jboss-1" ) );
-
-        version = new Version("1.2-GA");
-        version.appendQualifierSuffix( "jboss-2" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.GA-jboss-2" ) );
-
-        version = new Version("1.2-jboss");
-        version.appendQualifierSuffix( "jboss-2" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.jboss-2" ) );
-
-        version = new Version("1.2-jboss");
-        version.appendQualifierSuffix( "jboss-2" );
-        version.setBuildNumber( "3");
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.jboss-3" ) );
-
-        version = new Version("1.2.0-SNAPSHOT");
-        version.appendQualifierSuffix( "jboss-2" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.jboss-2-SNAPSHOT" ) );
-
-        version = new Version("1.2.3.4.GA.1");
-        version.appendQualifierSuffix( "jboss-1" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.3.4-GA-1-jboss-1" ) );
-    }
-
-    @Test
-    public void testSetBuildNumber()
-        throws Exception
-    {
-        Version version = new Version("1.2");
-        version.setBuildNumber( "1" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.1" ) );
-
-        version = new Version("1.2beta11");
-        version.setBuildNumber( "12" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.beta12" ) );
-
-        version = new Version("1.2.3.5");
-        version.setBuildNumber( "8" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.3.8" ) );
-
-        version = new Version("1.2-SNAPSHOT");
-        version.setBuildNumber( "1" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.1-SNAPSHOT" ) );
-
-        version = new Version("1.2-jboss-9-foo");
-        version.setBuildNumber( "10" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.jboss-9-foo-10" ) );
-
-        version = new Version("1.2.1.Final-jboss-8");
-        version.setBuildNumber( "9" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.1.Final-jboss-9" ) );
-
-        version = new Version("1.2.0-GA");
-        version.appendQualifierSuffix( "foo" );
-        version.setBuildNumber( "2" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.GA-foo-2" ) );
-    }
-
-    @Test
-    public void testFindHighestMatchingOSGiBuildNumber()
-    {
+    public void testFindHighestMatchingBuildNumber() {
+        String version = "1.2.0.Final-foo";
         final Set<String> versionSet = new HashSet<>();
-        Version version = new Version( "1.2.0.Final-foo" );
-        versionSet.add( "1.2.0.Final-foo-10" );
-        versionSet.add( "1.2.0.Final-foo-2" );
-        assertThat( findHighestMatchingBuildNumber( version, versionSet ), equalTo( 10 ) );
-        versionSet.clear();
-    }
+        versionSet.add("1.2.0.Final-foo-1");
+        versionSet.add("1.2.0.Final-foo-2");
+        assertThat(Version.findHighestMatchingBuildNumber(version, versionSet), equalTo(2));
 
-    @Test
-    public void testFindHighestMatchingBuildNumber()
-    {
-        final Set<String> versionSet = new HashSet<>();
-        Version version = new Version("1.2.0.Final-foo");
-        versionSet.add( "1.2.0.Final-foo-1" );
-        versionSet.add( "1.2.0.Final-foo-2" );
-        assertThat( findHighestMatchingBuildNumber( version, versionSet ), equalTo( 2 ) );
+        version = "1.2.0.Final-foo10";
         versionSet.clear();
+        versionSet.add("1.2.0.Final-foo-1");
+        versionSet.add("1.2.0.Final-foo-2");
+        assertThat(Version.findHighestMatchingBuildNumber(version, versionSet), equalTo(2));
 
-        version = new Version("0.0.4");
-        version.appendQualifierSuffix( "redhat-0" );
+        version = Version.appendQualifierSuffix( "0.0.4", "redhat-0" );
+        versionSet.clear();
         versionSet.add( "0.0.1" );
         versionSet.add( "0.0.2" );
         versionSet.add( "0.0.3" );
         versionSet.add( "0.0.4" );
         versionSet.add( "0.0.4.redhat-2" );
-        assertThat( findHighestMatchingBuildNumber( version, versionSet ), equalTo( 2 ) );
-        versionSet.clear();
+        assertThat( Version.findHighestMatchingBuildNumber( version, versionSet ), equalTo( 2 ) );
 
-        version = new Version("1.2-foo-1");
+        version = "1.2-foo-1";
+        versionSet.clear();
         versionSet.add( "1.2-foo-4" );
-        assertThat( findHighestMatchingBuildNumber( version, versionSet ), equalTo( 4 ) );
-        versionSet.clear();
+        assertThat( Version.findHighestMatchingBuildNumber( version, versionSet ), equalTo( 4 ) );
     }
 
     @Test
-    public void testZeroFill_FindHighestMatchingBuildNumber()
+    public void testFindHighestMatchingBuildNumber_OSGi()
     {
+        String version = "1.2.0.Final-foo";
         final Set<String> versionSet = new HashSet<>();
-        final Version majorOnlyVersion = new Version( "7" );
-        majorOnlyVersion.appendQualifierSuffix( "redhat" );
-        System.out.println("OSGi version: " + majorOnlyVersion.getOSGiVersionString());
-        versionSet.add( "7.0.0.redhat-2" );
-        assertThat( findHighestMatchingBuildNumber( majorOnlyVersion, versionSet ), equalTo( 2 ) );
-        versionSet.clear();
-
-        final Version majorMinorVersion = new Version( "7.1" );
-        majorMinorVersion.appendQualifierSuffix( "redhat" );
-        System.out.println("OSGi version: " + majorMinorVersion.getOSGiVersionString());
-        versionSet.add( "7.1.0.redhat-2" );
-        assertThat( findHighestMatchingBuildNumber( majorMinorVersion, versionSet ), equalTo( 2 ) );
+        versionSet.add( "1.2.0.Final-foo-10" );
+        versionSet.add( "1.2.0.Final-foo-2" );
+        assertThat( Version.findHighestMatchingBuildNumber( version, versionSet ), equalTo( 10 ) );
         versionSet.clear();
     }
-    
+
     @Test
-    public void testSetQualifierSuffix_MulitpleTimes()
+    public void testFindHighestMatchingBuildNumber_ZeroFill()
+    {
+        String majorOnlyVersion = "7";
+        String version = Version.appendQualifierSuffix( majorOnlyVersion, "redhat" );
+        final Set<String> versionSet = new HashSet<>();
+        versionSet.add( "7.0.0.redhat-2" );
+        assertThat( Version.findHighestMatchingBuildNumber( version, versionSet ), equalTo( 2 ) );
+
+        String majorMinorVersion = "7.1";
+        version = Version.appendQualifierSuffix( majorMinorVersion, "redhat" );
+        versionSet.clear();
+        versionSet.add( "7.1.0.redhat-4" );
+        assertThat( Version.findHighestMatchingBuildNumber( version, versionSet ), equalTo( 4 ) );
+    }
+
+    @Test
+    public void testGetBuildNumber()
+    {
+        assertThat( Version.getBuildNumber( "1.0-SNAPSHOT" ), equalTo( "" ) );
+        assertThat( Version.getBuildNumber( "1.0.0.Beta1" ), equalTo( "1" ) );
+        assertThat( Version.getBuildNumber( "1.0.beta.1-2" ), equalTo( "2" ) );
+        assertThat( Version.getBuildNumber( "Beta3" ), equalTo( "3" ) );
+        assertThat( Version.getBuildNumber( "1.x.2.beta4t" ), equalTo( "" ) );
+        assertThat( Version.getBuildNumber( "1.0.0.Beta11-SNAPSHOT" ), equalTo( "11" ) );
+        assertThat( Version.getBuildNumber( "1.0.0.Beta1-SNAPSHOT-10" ), equalTo( "10" ) );
+    }
+
+    @Test
+    public void testGetMMM()
+    {
+        assertThat( Version.getMMM( "1.0-SNAPSHOT" ), equalTo( "1.0" ) );
+        assertThat( Version.getMMM( "1.0.0.Beta1" ), equalTo( "1.0.0" ) );
+        assertThat( Version.getMMM( "1.0.beta.1" ), equalTo( "1.0" ) );
+        assertThat( Version.getMMM( "Beta1" ), equalTo( "" ) );
+        assertThat( Version.getMMM( "1.x.2.beta1" ), equalTo( "1" ) );
+    }
+
+    @Test
+    public void testGetOsgiMMM()
+    {
+        assertThat( Version.getOsgiMMM( "1.0", false ), equalTo( "1.0" ) );
+        assertThat( Version.getOsgiMMM( "1.0", true ), equalTo( "1.0.0" ) );
+        assertThat( Version.getOsgiMMM( "13_2-43", false ), equalTo( "13.2.43" ) );
+        assertThat( Version.getOsgiMMM( "1", false ), equalTo( "1" ) );
+        assertThat( Version.getOsgiMMM( "2", true ), equalTo( "2.0.0" ) );
+        assertThat( Version.getOsgiMMM( "beta1", false ), equalTo( "" ) );
+        assertThat( Version.getOsgiMMM( "GA-1-GA-foo", true ), equalTo( "" ) );
+    }
+
+    @Test
+    public void testGetOsgiVersion()
+    {
+        assertThat( Version.getOsgiVersion( "1.0" ), equalTo( "1.0" ) );
+        assertThat( Version.getOsgiVersion( "1_2_3" ), equalTo( "1.2.3" ) );
+        assertThat( Version.getOsgiVersion( "1-2.3beta4" ), equalTo( "1.2.3.beta4" ) );
+        assertThat( Version.getOsgiVersion( "1.2.3.4.beta" ), equalTo( "1.2.3.4-beta" ) );
+        assertThat( Version.getOsgiVersion( "12.4-beta" ), equalTo( "12.4.0.beta" ) );
+        assertThat( Version.getOsgiVersion( "-beta1" ), equalTo( "-beta1" ) );
+        assertThat( Version.getOsgiVersion( "12.beta1_3-5.hello" ), equalTo( "12.0.0.beta1_3-5-hello" ) );
+    }
+
+    @Test
+    public void testGetQualifier()
+    {
+        assertThat( Version.getQualifier( "1.0-SNAPSHOT" ), equalTo( "SNAPSHOT" ) );
+        assertThat( Version.getQualifierWithDelim( "1.0-SNAPSHOT" ), equalTo( "-SNAPSHOT" ) );
+
+        assertThat( Version.getQualifier( "1.0.0.Beta1" ), equalTo( "Beta1" ) );
+        assertThat( Version.getQualifierWithDelim( "1.0.0.Beta1" ), equalTo( ".Beta1" ) );
+
+        assertThat( Version.getQualifier( "1.0.beta.1" ), equalTo( "beta.1" ) );
+        assertThat( Version.getQualifierWithDelim( "1.0.beta.1" ), equalTo( ".beta.1" ) );
+
+        assertThat( Version.getQualifier( "Beta1" ), equalTo( "Beta1" ) );
+        assertThat( Version.getQualifierWithDelim( "Beta1" ), equalTo( "Beta1" ) );
+
+        assertThat( Version.getQualifier( "1.x.2.beta1" ), equalTo( "x.2.beta1" ) );
+        assertThat( Version.getQualifierWithDelim( "1.x.2.beta1" ), equalTo( ".x.2.beta1" ) );
+
+        assertThat( Version.getQualifier( "1.2" ), equalTo( "" ) );
+        assertThat( Version.getQualifierWithDelim( "1.2" ), equalTo( "" ) );
+
+        assertThat( Version.getQualifier( "1.5-3_beta-SNAPSHOT-1" ), equalTo( "beta-SNAPSHOT-1" ) );
+        assertThat( Version.getQualifierWithDelim( "1.5-3_beta-SNAPSHOT-1" ), equalTo( "_beta-SNAPSHOT-1" ) );
+
+        assertThat( Version.getQualifier( "_beta-SNAPSHOT-1" ), equalTo( "beta-SNAPSHOT-1" ) );
+        assertThat( Version.getQualifierWithDelim( "_beta-SNAPSHOT-1" ), equalTo( "_beta-SNAPSHOT-1" ) );
+    }
+
+    @Test
+    public void testGetSnapshot()
+    {
+        assertThat( Version.getSnapshot( "1.0-SNAPSHOT" ), equalTo( "SNAPSHOT" ) );
+        assertThat( Version.getSnapshotWithDelim( "1.0-SNAPSHOT" ), equalTo( "-SNAPSHOT" ) );
+
+        assertThat( Version.getSnapshot( "1.0.0.SNAPSHOT" ), equalTo( "SNAPSHOT" ) );
+        assertThat( Version.getSnapshotWithDelim( "1.0.0.SNAPSHOT" ), equalTo( ".SNAPSHOT" ) );
+
+        assertThat( Version.getSnapshot( "1.0.0.Beta1-snapshot" ), equalTo( "snapshot" ) );
+        assertThat( Version.getSnapshotWithDelim( "1.0.0.Beta1-snapshot" ), equalTo( "-snapshot" ) );
+
+        assertThat( Version.getSnapshot( "1_snaPsHot" ), equalTo( "snaPsHot" ) );
+        assertThat( Version.getSnapshotWithDelim( "1_snaPsHot" ), equalTo( "_snaPsHot" ) );
+
+        assertThat( Version.getSnapshot( "1.0" ), equalTo( "" ) );
+        assertThat( Version.getSnapshotWithDelim( "1.0" ), equalTo( "" ) );
+
+        assertThat( Version.getSnapshot( "1.0-foo" ), equalTo( "" ) );
+        assertThat( Version.getSnapshotWithDelim( "1.0-foo" ), equalTo( "" ) );
+    }
+
+    @Test
+    public void testIsSnapshot()
+    {
+        assertTrue( Version.isSnapshot( "1.0-SNAPSHOT" ) );
+        assertTrue( Version.isSnapshot( "1.0-snapshot" ) );
+        assertTrue( Version.isSnapshot( "1.0.SnapsHot" ) );
+        assertTrue( Version.isSnapshot( "1.0.0snapshot" ) );
+        assertTrue( Version.isSnapshot( "snapshot" ) );
+
+        assertFalse( Version.isSnapshot( "1" ) );
+        assertFalse( Version.isSnapshot( "1.0-snapsho" ) );
+        assertFalse( Version.isSnapshot( "1.0.beta1-" ) );
+    }
+
+    @Test
+    public void testIsEmpty()
+            throws Exception
+    {
+        assertTrue( Version.isEmpty(null) );
+        assertTrue( Version.isEmpty("") );
+        assertTrue( Version.isEmpty("  \n") );
+
+        assertFalse( Version.isEmpty( "a") );
+        assertFalse( Version.isEmpty( " a \n") );
+    }
+
+    @Test
+    public void testRemoveSnapshot()
+    {
+        assertThat( Version.removeSnapshot( "1.0-SNAPSHOT" ), equalTo( "1.0" ) );
+        assertThat( Version.removeSnapshot( "1.0.0.Beta1_snapshot" ), equalTo( "1.0.0.Beta1" ) );
+        assertThat( Version.removeSnapshot( "1.snaPsHot" ), equalTo( "1" ) );
+        assertThat( Version.removeSnapshot( "SNAPSHOT" ), equalTo( "" ) );
+        assertThat( Version.removeSnapshot( "1.0.snapshot.beta1" ), equalTo( "1.0.snapshot.beta1" ) );
+    }
+
+    @Test
+    public void testSetBuildNumber()
+    {
+        assertThat( Version.setBuildNumber( "1.0.beta1", "2" ), equalTo( "1.0.beta2") );
+        assertThat( Version.setBuildNumber( "1.0_2-Beta1-SNAPSHOT", "41" ), equalTo( "1.0_2-Beta41-SNAPSHOT") );
+        assertThat( Version.setBuildNumber( "1.0.2.1", "3" ), equalTo( "1.0.2.3") );
+        assertThat( Version.setBuildNumber( "1.0.2", "3" ), equalTo( "1.0.2.3") );
+        assertThat( Version.setBuildNumber( "1.0", "2" ), equalTo( "1.0.2") );
+        assertThat( Version.setBuildNumber( "1.0-alpha", "001" ), equalTo( "1.0-alpha-001") );
+    }
+
+    @Test
+    public void testSetSnapshot()
+    {
+        assertThat( Version.setSnapshot( "1.0-SNAPSHOT", true ), equalTo( "1.0-SNAPSHOT" ) );
+        assertThat( Version.setSnapshot( "1.0-SNAPSHOT", false ), equalTo( "1.0" ) );
+        assertThat( Version.setSnapshot( "1.0.0.Beta1_snapshot", true ), equalTo( "1.0.0.Beta1_snapshot" ) );
+        assertThat( Version.setSnapshot( "1.0.0.Beta1_snapshot", false ), equalTo( "1.0.0.Beta1" ) );
+        assertThat( Version.setSnapshot( "1.snaPsHot", true ), equalTo( "1.snaPsHot" ) );
+        assertThat( Version.setSnapshot( "1.snaPsHot", false ), equalTo( "1" ) );
+        assertThat( Version.setSnapshot( "SNAPSHOT", true ), equalTo( "SNAPSHOT" ) );
+        assertThat( Version.setSnapshot( "SNAPSHOT", false ), equalTo( "" ) );
+        assertThat( Version.setSnapshot( "1.0.snapshot.beta1", true ), equalTo( "1.0.snapshot.beta1-SNAPSHOT" ) );
+        assertThat( Version.setSnapshot( "1.0.snapshot.beta1", false ), equalTo( "1.0.snapshot.beta1" ) );
+    }
+
+    @Test
+    public void testStripLeadingDelimiters()
+    {
+        assertThat( Version.removeLeadingDelimiter( ".1.2" ), equalTo( "1.2" ) );
+        assertThat( Version.removeLeadingDelimiter( "_Beta1" ), equalTo( "Beta1" ) );
+        assertThat( Version.removeLeadingDelimiter( "1.0-SNAPSHOT" ), equalTo( "1.0-SNAPSHOT" ) );
+        assertThat( Version.removeLeadingDelimiter( "1.0_foo-" ), equalTo( "1.0_foo-" ) );
+    }
+
+    @Test
+    public void testValidOsgi()
         throws Exception
     {
+        assertTrue( Version.isValidOSGi("1") );
+        assertTrue( Version.isValidOSGi("1.2") );
+        assertTrue( Version.isValidOSGi("1.2.3") );
+        assertTrue( Version.isValidOSGi("1.2.3.beta1") );
+        assertTrue( Version.isValidOSGi("1.2.3.beta_1") );
+        assertTrue( Version.isValidOSGi("1.2.3.beta-1") );
+        assertTrue( Version.isValidOSGi("0.0.1") );
 
-        Version version = new Version("1.2.0");
-        version.appendQualifierSuffix( "jboss-1" );
-        version.appendQualifierSuffix( "foo" );
-        assertThat( version.getVersionString(), equalTo( "1.2.0.jboss-1-foo" ) );
-
-        version = new Version("1.2");
-        version.appendQualifierSuffix( "jboss-1" );
-        version.appendQualifierSuffix( "jboss-2" );
-        assertThat( version.getOSGiVersionString(), equalTo( "1.2.0.jboss-2" ) );
-
+        assertFalse( Version.isValidOSGi("1.2.3.beta|1") );
+        assertFalse( Version.isValidOSGi("1.2.3.beta^1") );
+        assertFalse( Version.isValidOSGi("1.2.3.beta.1") );
+        assertFalse( Version.isValidOSGi("1.2.beta1") );
+        assertFalse( Version.isValidOSGi("1beta") );
+        assertFalse( Version.isValidOSGi("beta1") );
     }
+
+
 }

--- a/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersioningCalculatorTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersioningCalculatorTest.java
@@ -937,15 +937,12 @@ public class VersioningCalculatorTest
     private String calculate( final String version )
         throws Exception
     {
-        Version modifiedVersion = modder.calculate( GROUP_ID, ARTIFACT_ID, version, session );
+        String modifiedVersion = modder.calculate( GROUP_ID, ARTIFACT_ID, version, session );
         if ( session.getState( VersioningState.class ).osgi() )
         {
-            return modifiedVersion.getOSGiVersionString(); 
+            return Version.getOsgiVersion( modifiedVersion );
         }
-        else
-        {
-            return modifiedVersion.getVersionString();
-        }
+        return modifiedVersion;
     }
 
     private VersioningState setupSession( final Properties properties, final String... versions )
@@ -1022,7 +1019,7 @@ public class VersioningCalculatorTest
         }
 
         @Override
-        public Version calculate( final String groupId, final String artifactId,
+        public String calculate( final String groupId, final String artifactId,
                                              final String originalVersion, final ManipulationSession session )
             throws ManipulationException
         {

--- a/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersioningCalculatorTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/manip/impl/VersioningCalculatorTest.java
@@ -139,13 +139,11 @@ public class VersioningCalculatorTest
         }
     }
 
-    @Test
     /**
      * Not every version form know to man is converted...but we should try to
      * safely handle unknown forms.
-     *
-     * @throws Exception
      */
+    @Test
     public void osgi_fallback()
         throws Exception
     {


### PR DESCRIPTION
The Version class no longer stores any state about the version,
each version string modification is an independent operation which should
hopefully mean easier testing and debugging