### PR TITLE
Allow dependencyOverrides to reference a remote BOM as a version

### DIFF
--- a/integration-test/src/it/remote-dependency-management-extrabom/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-extrabom/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.commonjava.maven.ext.integration-test</groupId>
+  <artifactId>basic-dependency-override</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test override dependency version using command line property</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.2</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.1</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/integration-test/src/it/remote-dependency-management-extrabom/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-extrabom/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test;
+
+import org.junit.Test;
+
+public class HelloWorldwithJUnit
+{
+    public static void main (String [] args)
+    {
+        System.out.println("hello");
+    }
+
+    @Test
+    public void test()
+    {
+        // Just a dummy method to verify that we can compile again JUnit 4
+    }
+}

--- a/integration-test/src/it/remote-dependency-management-extrabom/test.properties
+++ b/integration-test/src/it/remote-dependency-management-extrabom/test.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# Override the version of JUnit
+# The colon needs to be escaped to prevent the invoker plugin from misinterpreting it
+dependencyManagement=org.commonjava.maven.ext.integration-test\:depMgmt1\:1.0
+strictAlignment=false
+dependencyManagement.xyzzy=org.commonjava.maven.ext.integration-test\:depMgmt4\:1.0
+dependencyOverride.commons-lang\:commons-lang\:*@*=xyzzy

--- a/integration-test/src/it/remote-dependency-management-extrabom/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-extrabom/verify.groovy
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def pomFile = new File( basedir, 'pom.xml' )
+System.out.println( "Slurping POM: ${pomFile.getAbsolutePath()}" )
+
+def pom = new XmlSlurper().parse( pomFile )
+
+def dependency = pom.dependencies.dependency.find { it.artifactId.text() == "junit" }
+assert dependency != null
+assert dependency.version.text() == "4.1"
+
+def dependency2 = pom.dependencies.dependency.find { it.artifactId.text() == "commons-lang" }
+assert dependency2 != null
+assert dependency2.version.text() == "2.6"

--- a/integration-test/src/it/setup/depMgmt4/invoker.properties
+++ b/integration-test/src/it/setup/depMgmt4/invoker.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Goals specific to current project
+invoker.goals = clean install

--- a/integration-test/src/it/setup/depMgmt4/pom.xml
+++ b/integration-test/src/it/setup/depMgmt4/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.commonjava.maven.ext.integration-test</groupId>
+  <artifactId>depMgmt4</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Dependency Management POM to use with integration tests</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>2.6</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>2.6</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/io/src/main/java/org/commonjava/maven/ext/io/ModelIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/ModelIO.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
@@ -184,6 +185,20 @@ public class ModelIO
         }
 
         return versionOverrides;
+    }
+
+    public Map<ProjectRef, String> getRemoteDependencyVersionOverridesByProject( final ProjectVersionRef ref )
+        throws ManipulationException
+    {
+        Map<ArtifactRef, String> byArtifact = getRemoteDependencyVersionOverrides( ref );
+        return byArtifact.entrySet()
+                         .stream()
+                         .collect( Collectors.toMap( e -> e.getKey()
+                                                           .asProjectRef(),
+                                                     Map.Entry::getValue, ( key1, key2 ) -> {
+                                                         // Avoid problem where a ProjectRef leads to duplicates when the ArtifactRef didn't
+                                                         return key1;
+                                                     } ) );
     }
 
     public Properties getRemotePropertyMappingOverrides( final ProjectVersionRef ref )


### PR DESCRIPTION
This allows for more than one `dependencyManagement` BOM to be used when they
would otherwise conflict. The `dependencyOverride`/`dependencyExclusion`s limit
these "extra BOMs" effect to their requested modules/artifacts only.

The core RH-SSO server needs to align to EAP 7.x, but it also must build an
adapter that compiles against EAP 6.x. Before this change, the way to do this
would be:

```
-DdependencyManagement=org.jboss.eap:jboss-eap-parent:7.2.0.GA-redhat
-DdependencyRelocations.org.wildfly:@org.jboss.eap:=7.2.0.GA-redhat
-DdependencyOverride.org.jboss.as:*@*=7.5.20.Final-redhat-1
-DdependencyOverride.org.jboss.web:jbossweb@*=7.5.28.Final-redhat-1
...
```

Which works, but requires manually synchronizing the dependencyOverrides. With
this change, this is how it'd look:

```
-DdependencyManagement=org.jboss.eap:jboss-eap-parent:7.2.0.GA-redhat
-DdependencyRelocations.org.wildfly:@org.jboss.eap:=7.2.0.GA-redhat
-DdependencyManagement.eap6=org.jboss.bom:eap6-supported-artifacts:6.4.21.GA
-DdependencyOverride.org.jboss.as:*@*=eap6
-DdependencyOverride.org.jboss.web:jbossweb@*=eap6
...
```

Which results in less churn and manual work.