### PR TITLE
Cleaned up multiple logging statements

### DIFF
--- a/core/src/main/java/org/commonjava/maven/ext/core/ManipulationManager.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/ManipulationManager.java
@@ -158,9 +158,10 @@ public class ManipulationManager
         session.getActiveProfiles().addAll( parseActiveProfiles( session, currentProjects ) );
         session.setProjects( currentProjects );
 
-        for ( final Project project : currentProjects )
-        {
-            logger.debug( "Got " + project + " (POM: " + project.getPom() + ")" );
+        if (logger.isDebugEnabled()) {
+            for (final Project project : currentProjects) {
+                logger.debug("Got {} (POM: {})", project, project.getPom());
+            }
         }
 
         Set<Project> changed = applyManipulations( currentProjects );
@@ -168,7 +169,7 @@ public class ManipulationManager
         // Create a marker file if we made some changes to prevent duplicate runs.
         if ( !changed.isEmpty() )
         {
-            logger.info( "Maven-Manipulation-Extension: Rewrite changed: " + currentProjects );
+            logger.info( "Maven-Manipulation-Extension: Rewrite changed: {}", currentProjects );
 
             GAV gav = pomIO.rewritePOMs( changed );
 
@@ -228,9 +229,14 @@ public class ManipulationManager
                 throw new ManipulationException( "Activation detection failure", e );
             }
         }
-        logger.debug( "Will {}scan all profiles and returning active profiles of {} ",
-                      Boolean.parseBoolean( session.getUserProperties().getProperty( PROFILE_SCANNING, PROFILE_SCANNING_DEFAULT ) ) ? "not " : "",
-                      activeProfiles );
+
+
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("Will {}scan all profiles and returning active profiles of {} ",
+                    Boolean.parseBoolean(session.getUserProperties().getProperty(PROFILE_SCANNING, PROFILE_SCANNING_DEFAULT)) ? "not " : "",
+                    activeProfiles);
+        }
 
         return activeProfiles;
     }

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/BOMBuilderManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/BOMBuilderManipulator.java
@@ -91,9 +91,10 @@ public class BOMBuilderManipulator
     {
         final BOMInjectingState state = session.getState( BOMInjectingState.class );
 
+
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName() );
             return Collections.emptySet();
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/DependencyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/DependencyManipulator.java
@@ -115,7 +115,7 @@ public class DependencyManipulator implements Manipulator
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName());
             return Collections.emptySet();
         }
         return internalApplyChanges( projects, loadRemoteOverrides() );
@@ -199,6 +199,7 @@ public class DependencyManipulator implements Manipulator
             mergedOverrides.putAll( bomOverrides );
         }
         logger.info ( "Remote precedence is {}", depState.getPrecedence() );
+
         logger.debug ("Final remote override list is {}", mergedOverrides);
         return mergedOverrides;
     }
@@ -640,11 +641,11 @@ public class DependencyManipulator implements Manipulator
 
                     if ( isEmpty( overrideVersion ) )
                     {
-                        logger.warn( "Unable to align with an empty override version for " + groupIdArtifactId + "; ignoring" );
+                        logger.warn( "Unable to align with an empty override version for {}; ignoring", groupIdArtifactId );
                     }
                     else if ( isEmpty( oldVersion ) )
                     {
-                        logger.debug( "Dependency is a managed version for " + groupIdArtifactId + "; ignoring" );
+                        logger.debug( "Dependency is a managed version for {}; ignoring", groupIdArtifactId );
                     }
                     else if (oldVersion.equals( "${project.version}" ) || ( oldVersion.contains( "$" ) && project.getVersion().equals( resolvedValue ) ) )
                     {
@@ -782,8 +783,11 @@ public class DependencyManipulator implements Manipulator
     {
         final Map<ArtifactRef, String> remainingOverrides = new LinkedHashMap<>( originalOverrides );
 
-        logger.debug( "Calculating module-specific version overrides. Starting with:\n  {}",
-                      join( remainingOverrides.entrySet(), "\n  " ) );
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("Calculating module-specific version overrides. Starting with:\n  {}",
+                    join(remainingOverrides.entrySet(), "\n  "));
+        }
 
         // These modes correspond to two different kinds of passes over the available override properties:
         // 1. Module-specific: Don't process wildcard overrides here, allow module-specific settings to take precedence.
@@ -883,7 +887,7 @@ public class DependencyManipulator implements Manipulator
                         // If we have a wildcard artifact we want to replace any prior explicit overrides
                         // with this one i.e. this takes precedence.
                         removeGA( remainingOverrides, SimpleProjectRef.parse( artifactGA ) );
-                        logger.debug( "Removing artifactGA " + artifactGA + " from overrides" );
+                        logger.debug( "Removing artifactGA {} from overrides", artifactGA );
                     }
                 }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/DistributionEnforcingManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/DistributionEnforcingManipulator.java
@@ -171,7 +171,7 @@ public class DistributionEnforcingManipulator
                 continue;
             }
 
-            logger.debug( "Applying skip-flag enforcement mode of: " + mode + " to: " + ga );
+            logger.debug( "Applying skip-flag enforcement mode of: {} to: {}", mode, ga );
 
             final Model model = project.getModel();
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/FinalGroovyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/FinalGroovyManipulator.java
@@ -74,7 +74,7 @@ public class FinalGroovyManipulator
         final GroovyState state = session.getState( GroovyState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName() );
             return Collections.emptySet();
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/InitialGroovyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/InitialGroovyManipulator.java
@@ -74,7 +74,7 @@ public class InitialGroovyManipulator
         final GroovyState state = session.getState( GroovyState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName() );
             return Collections.emptySet();
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/ParentInjectionManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/ParentInjectionManipulator.java
@@ -62,7 +62,7 @@ public class ParentInjectionManipulator
         final ParentInjectionState state = session.getState( ParentInjectionState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName());
             return Collections.emptySet();
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/PluginManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/PluginManipulator.java
@@ -293,7 +293,10 @@ public class PluginManipulator
     private void apply( final Project project, final Model model, PluginType type, final Set<Plugin> override )
         throws ManipulationException
     {
-        logger.debug( "Applying plugin changes for {} to: {} ", type, ga( project ) );
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("Applying plugin changes for {} to: {} ", type, ga(project));
+        }
 
         if ( project.isInheritanceRoot() )
         {
@@ -304,7 +307,7 @@ public class PluginManipulator
             {
                 build = new Build();
                 model.setBuild( build );
-                logger.debug( "Created new Build for model " + model.getId() );
+                logger.debug( "Created new Build for model {}", model.getId() );
             }
 
             PluginManagement pluginManagement = model.getBuild().getPluginManagement();
@@ -313,7 +316,7 @@ public class PluginManipulator
             {
                 pluginManagement = new PluginManagement();
                 model.getBuild().setPluginManagement( pluginManagement );
-                logger.debug( "Created new Plugin Management for model " + model.getId() );
+                logger.debug( "Created new Plugin Management for model {}", model.getId() );
             }
 
             // Override plugin management versions
@@ -423,15 +426,15 @@ public class PluginManipulator
                 {
                     if ( override.getConfiguration() != null )
                     {
-                        logger.debug( "Injecting plugin configuration" + override.getConfiguration() );
+                        logger.debug( "Injecting plugin configuration {}", override.getConfiguration() );
                         if ( plugin.getConfiguration() == null )
                         {
                             plugin.setConfiguration( override.getConfiguration() );
-                            logger.debug( "Altered plugin configuration: " + plugin.getKey() + "=" + plugin.getConfiguration() );
+                            logger.debug( "Altered plugin configuration: {}={}", plugin.getKey(), plugin.getConfiguration() );
                         }
                         else if ( plugin.getConfiguration() != null )
                         {
-                            logger.debug( "Existing plugin configuration: " + plugin.getConfiguration() );
+                            logger.debug( "Existing plugin configuration: {}", plugin.getConfiguration() );
 
                             if ( !( plugin.getConfiguration() instanceof Xpp3Dom ) || !( override.getConfiguration() instanceof Xpp3Dom ) )
                             {
@@ -451,12 +454,12 @@ public class PluginManipulator
                                 plugin.setConfiguration( Xpp3DomUtils.mergeXpp3Dom( (Xpp3Dom) plugin.getConfiguration(),
                                                                                     (Xpp3Dom) override.getConfiguration() ) );
                             }
-                            logger.debug( "Altered plugin configuration: " + plugin.getKey() + "=" + plugin.getConfiguration() );
+                            logger.debug( "Altered plugin configuration: {}={}", plugin.getKey(), plugin.getConfiguration() );
                         }
                     }
                     else
                     {
-                        logger.debug( "No remote configuration to inject from " + override.toString() );
+                        logger.debug( "No remote configuration to inject from {}", override.toString() );
                     }
 
                     if ( override.getExecutions() != null )
@@ -468,7 +471,8 @@ public class PluginManipulator
                         {
                             if ( originalExecutions.containsKey( pe.getId() ) )
                             {
-                                logger.warn( "Unable to inject execution " + pe.getId() + " as it clashes with an existing execution" );
+                                logger.warn( "Unable to inject execution {} as it clashes with an existing execution",
+                                        pe.getId());
                             }
                             else
                             {
@@ -479,7 +483,7 @@ public class PluginManipulator
                     }
                     else
                     {
-                        logger.debug( "No remote executions to inject from " + override.toString() );
+                        logger.debug( "No remote executions to inject from {}", override.toString() );
                     }
 
                     if ( !override.getDependencies().isEmpty() )
@@ -531,7 +535,7 @@ public class PluginManipulator
                     else
                     {
                         plugin.setVersion( newValue );
-                        logger.info( "Altered plugin version: " + override.getKey() + "=" + newValue );
+                        logger.info( "Altered plugin version: {}={}", override.getKey(), newValue );
                     }
                 }
             }
@@ -541,7 +545,7 @@ public class PluginManipulator
                             || override.getExecutions().size() > 0 ) )
             {
                 project.getModel().getBuild().getPluginManagement().getPlugins().add( override );
-                logger.info( "Added plugin version: " + override.getKey() + "=" + newValue );
+                logger.info( "Added plugin version: {}={}", override.getKey(), newValue );
             }
             // If the plugin in <plugins> doesn't exist but has a configuration section in the remote inject it so we
             // get the correct config.
@@ -550,8 +554,7 @@ public class PluginManipulator
                             || override.getExecutions().size() > 0 ) )
             {
                 project.getModel().getBuild().getPlugins().add( override );
-                logger.info( "For non-pluginMgmt, added plugin version : " + override.getKey() + "="
-                                             + newValue );
+                logger.info( "For non-pluginMgmt, added plugin version : {}={}", override.getKey(), newValue );
             }
         }
     }

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/PluginRemovalManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/PluginRemovalManipulator.java
@@ -97,7 +97,11 @@ public class PluginRemovalManipulator
     {
         final PluginRemovalState state = session.getState( PluginRemovalState.class );
 
-        logger.debug( "Applying plugin changes to: " + ga( project ) );
+        if (logger.isDebugEnabled())
+        {
+            logger.debug( "Applying plugin changes to: {}", ga( project ) );
+        }
+
 
         boolean result = false;
         List<ProjectRef> pluginsToRemove = state.getPluginRemoval();

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/ProfileRemovalManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/ProfileRemovalManipulator.java
@@ -67,7 +67,7 @@ public class ProfileRemovalManipulator
         final ProfileRemovalState state = session.getState( ProfileRemovalState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName());
             return Collections.emptySet();
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/ProjectVersioningManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/ProjectVersioningManipulator.java
@@ -161,7 +161,7 @@ public class ProjectVersioningManipulator
             if ( versionsByGAV.containsKey( parentGAV ) )
             {
                 final String newVersion = versionsByGAV.get( parentGAV );
-                logger.debug( "Changed parent version to: " + newVersion + " in " + parent );
+                logger.debug( "Changed parent version to: {} in {}", newVersion, parent );
                 if (parentGAV.getVersionString().startsWith( "${" ))
                 {
                     if ( PropertiesUtils.updateProperties( session, project, false, PropertiesUtils.extractPropertyName( parentGAV.getVersionString() ), newVersion ) == PropertiesUtils.PropertyUpdate.NOTFOUND )
@@ -181,7 +181,7 @@ public class ProjectVersioningManipulator
         if ( model.getVersion() != null )
         {
             final String newVersion = versionsByGAV.get( gav );
-            logger.info( "Looking for new version: " + gav + " (found: " + newVersion + ")" );
+            logger.info( "Looking for new version: {} (found: {})", gav, newVersion );
             if ( newVersion != null )
             {
                 if (gav.getVersionString().startsWith( "${" ))
@@ -195,7 +195,7 @@ public class ProjectVersioningManipulator
                 {
                     model.setVersion( newVersion );
                 }
-                logger.info( "Changed main version in " + project );
+                logger.info( "Changed main version in {}", project );
                 changed = true;
             }
         }
@@ -205,7 +205,7 @@ public class ProjectVersioningManipulator
         else if ( !changed && project.isInheritanceRoot() )
         {
             final String newVersion = versionsByGAV.get( gav );
-            logger.info( "Looking to force inject new version for : " + gav + " (found: " + newVersion + ")" );
+            logger.info( "Looking to force inject new version for : {} (found: {})", gav, newVersion );
             if (newVersion != null)
             {
                 model.setVersion( newVersion );
@@ -227,7 +227,7 @@ public class ProjectVersioningManipulator
                 {
                     if ( isEmpty (pi.interp( d.getVersion() )))
                     {
-                        logger.trace( "Skipping dependency " + d + " as empty version." );
+                        logger.trace( "Skipping dependency {} as empty version.", d);
                         continue;
                     }
                     try
@@ -249,7 +249,7 @@ public class ProjectVersioningManipulator
                             else
                             {
                                 d.setVersion( newVersion );
-                                logger.info( "Changed managed: " + d + " in " + base + " to " + newVersion + " from " + gav.getVersionString() );
+                                logger.info( "Changed managed: {} in {} to {} from {}", d, base, newVersion, gav.getVersionString() );
                             }
                             changed = true;
                         }
@@ -270,7 +270,7 @@ public class ProjectVersioningManipulator
                     {
                         if ( isEmpty (pi.interp( d.getVersion() )))
                         {
-                            logger.trace( "Skipping dependency " + d + " as empty version." );
+                            logger.trace( "Skipping dependency {} as empty version.", d );
                             continue;
                         }
 
@@ -293,7 +293,7 @@ public class ProjectVersioningManipulator
                             else
                             {
                                 d.setVersion( newVersion );
-                                logger.info( "Changed: " + d + " in " + base + " to " + newVersion + " from " + gav.getVersionString());
+                                logger.info( "Changed: {} in {} to {} from {}", d, base, newVersion, gav.getVersionString());
                             }
                             changed = true;
                         }

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/PropertyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/PropertyManipulator.java
@@ -76,7 +76,7 @@ public class PropertyManipulator
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName() );
             return Collections.emptySet();
         }
 
@@ -90,7 +90,7 @@ public class PropertyManipulator
                 // Only inject the new properties at the top level.
                 if ( project.isInheritanceRoot() )
                 {
-                    logger.info( "Applying property changes to: " + ga( project ) + " with " + overrides );
+                    logger.info( "Applying property changes to: {} with {}", ga( project ), overrides );
 
                     project.getModel().getProperties().putAll( overrides );
 
@@ -109,7 +109,7 @@ public class PropertyManipulator
                         while (keys.hasNext())
                         {
                             final String matchingKey = keys.next();
-                            logger.info( "Overwriting property (" + matchingKey + " in: " + ga( project ) + " with value " + overrides.get( matchingKey ) );
+                            logger.info( "Overwriting property ({} in: {} with value {}", matchingKey, ga( project ), overrides.get( matchingKey ));
                             project.getModel().getProperties().put( matchingKey, overrides.get( matchingKey ) );
 
                             changed.add( project );

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/RESTBOMCollector.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/RESTBOMCollector.java
@@ -87,7 +87,7 @@ public class RESTBOMCollector
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName());
             return;
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/RESTCollector.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/RESTCollector.java
@@ -86,7 +86,7 @@ public class RESTCollector
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName());
             return;
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/RangeResolver.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/RangeResolver.java
@@ -83,7 +83,7 @@ public class RangeResolver
 
         if ( !session.isEnabled() || !session.anyStateEnabled( State.activeByDefault ) || state == null || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName());
             return Collections.emptySet();
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/RelocationManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/RelocationManipulator.java
@@ -84,7 +84,7 @@ public class RelocationManipulator
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName());
             return Collections.emptySet();
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/RepoAndReportingRemovalManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/RepoAndReportingRemovalManipulator.java
@@ -100,7 +100,7 @@ public class RepoAndReportingRemovalManipulator
         for ( final Project project : projects )
         {
             final String ga = ga( project );
-            logger.debug( "Applying changes to: " + ga );
+            logger.debug( "Applying changes to: {}", ga );
             final Model model = project.getModel();
 
             Iterator<Repository> it = model.getRepositories().iterator();

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/RepositoryInjectionManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/RepositoryInjectionManipulator.java
@@ -81,7 +81,7 @@ public class RepositoryInjectionManipulator
         final RepositoryInjectionState state = session.getState( RepositoryInjectionState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName() );
             return Collections.emptySet();
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/SuffixManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/SuffixManipulator.java
@@ -65,6 +65,8 @@ public class SuffixManipulator
         session.setState( new SuffixState( session.getUserProperties() ) );
     }
 
+
+
     /**
      * Apply the property changes to the list of {@link Project}'s given.
      */
@@ -75,7 +77,7 @@ public class SuffixManipulator
 
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName());
             return Collections.emptySet();
         }
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/Version.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/Version.java
@@ -199,7 +199,7 @@ public class Version
         String mmm = getOsgiMMM( version, !isEmpty( qualifier ) );
         if ( isEmpty( mmm ) )
         {
-            logger.warn( "Unable to parse version for OSGi: " + version );
+            logger.warn( "Unable to parse version for OSGi: {}", version );
             return version;
         }
         return mmm + qualifier;
@@ -476,8 +476,7 @@ public class Version
     {
         if ( !isNumeric( buildNumber ) )
         {
-            logger.warn("Failed attempt to set non-numeric build number '" + buildNumber + "' for version '"
-                    + version + "'");
+            logger.warn("Failed attempt to set non-numeric build number '{}' for version '{}'", buildNumber, version);
             return version;
         }
         if ( isEmpty( buildNumber ) )

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/VersionCalculator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/VersionCalculator.java
@@ -124,7 +124,12 @@ public class VersionCalculator
             }
 
             versionsWithBuildNums.add( modifiedVersion );
-            logger.debug( gav( project ) + " has updated version: {}. Marking for rewrite.", modifiedVersion );
+
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("{} has updated version: {}. Marking for rewrite.", gav( project ), modifiedVersion );
+            }
+
 
             if ( !originalVersion.equals( modifiedVersion ) )
             {
@@ -171,11 +176,16 @@ public class VersionCalculator
         final String staticSuffix = state.getSuffix();
         final String override = state.getOverride();
 
-        logger.debug( "Got the following original version: {} for groupId:artifactId {}:{} ", version, groupId,
-                      artifactId );
-        logger.debug( "Got the following version suffixes:\n  Static: {}\n  Incremental: {}", staticSuffix,
-                      incrementalSuffix );
-        logger.debug( "Got the following version override: {}", override );
+
+        if (logger.isDebugEnabled())
+        {
+            logger.debug( "Got the following original version: {} for groupId:artifactId {}:{} ", version, groupId,
+                    artifactId );
+            logger.debug( "Got the following version suffixes:\n  Static: {}\n  Incremental: {}", staticSuffix,
+                    incrementalSuffix );
+            logger.debug( "Got the following version override: {}", override );
+        }
+
 
         String newVersion = version;
 

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/XMLManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/XMLManipulator.java
@@ -87,7 +87,7 @@ public class XMLManipulator
         final XMLState state = session.getState( XMLState.class );
         if ( !session.isEnabled() || !state.isEnabled() )
         {
-            logger.debug( getClass().getSimpleName() + ": Nothing to do!" );
+            logger.debug("{}: Nothing to do!", getClass().getSimpleName());
             return Collections.emptySet();
         }
 
@@ -128,7 +128,7 @@ public class XMLManipulator
             {
                 if ( project.isIncrementalPME() )
                 {
-                    logger.warn ("Did not locate XML using XPath " + operation.getXPath() );
+                    logger.warn ("Did not locate XML using XPath {}", operation.getXPath() );
                     return;
                 }
                 else

--- a/io/src/main/java/org/commonjava/maven/ext/io/ModelIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/ModelIO.java
@@ -293,12 +293,12 @@ public class ModelIO
 
             if ( type == PluginType.PluginMgmt && m.getBuild().getPluginManagement() != null )
             {
-                logger.debug( "Returning override of " + m.getBuild().getPluginManagement().getPlugins() );
+                logger.debug( "Returning override of {}", m.getBuild().getPluginManagement().getPlugins() );
                 plit = m.getBuild().getPluginManagement().getPlugins().iterator();
             }
             else if ( type == PluginType.Plugins && m.getBuild().getPlugins() != null)
             {
-                logger.debug( "Returning override of " + m.getBuild().getPlugins() );
+                logger.debug( "Returning override of {}", m.getBuild().getPlugins() );
                 plit = m.getBuild().getPlugins().iterator();
             }
 
@@ -319,8 +319,7 @@ public class ModelIO
                         newVersion = pluginOverridesPomView.get( pr ).getVersionString();
                     }
 
-                    logger.debug( "Replacing plugin override version " + p.getVersion() +
-                                                  " with " + newVersion );
+                    logger.debug( "Replacing plugin override version {} with {}", p.getVersion(), newVersion );
                      p.setVersion( newVersion );
                 }
 
@@ -362,8 +361,11 @@ public class ModelIO
                     }
                 }
 
-                logger.debug( "Added plugin override for {} with configuration \n" + p.getConfiguration() + " and executions "
-                                              + p.getExecutions() + " and dependencies " + p.getDependencies(), p.getId() );
+                if (logger.isDebugEnabled()) {
+                    logger.debug( "Added plugin override for {} with configuration \n{} and executions {} and dependencies {}",
+                            p.getId(), p.getExecutions(), p.getDependencies());
+                }
+
             }
         }
         else
@@ -396,7 +398,7 @@ public class ModelIO
 
                 if ( replacement != null && !replacement.isEmpty() )
                 {
-                    logger.debug( "Replacing child value " + child.getValue() + " with " + replacement );
+                    logger.debug( "Replacing child value {} with {}", child.getValue(), replacement );
                     child.setValue( replacement );
                 }
             }

--- a/io/src/main/java/org/commonjava/maven/ext/io/PomIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/PomIO.java
@@ -121,8 +121,13 @@ public class PomIO
 
             if ( executionRoot.equals( pom ))
             {
-                logger.debug( "Setting execution root to {} with file {}" +
-                      (project.isInheritanceRoot() ? " and is the inheritance root. ": ""), project, pom );
+
+                if (logger.isDebugEnabled())
+                {
+                    logger.debug("Setting execution root to {} with file {}" +
+                            (project.isInheritanceRoot() ? " and is the inheritance root. " : ""), project, pom);
+                }
+
                 project.setExecutionRoot ();
 
                 try
@@ -184,12 +189,17 @@ public class PomIO
             {
                 result = new GAV( project.getKey() );
             }
-            logger.debug( String.format( "%s modified! Rewriting.", project ) );
+
+            if (logger.isDebugEnabled())
+            {
+                logger.debug(String.format("%s modified! Rewriting.", project));
+            }
+
             File pom = project.getPom();
 
             final Model model = project.getModel();
-            logger.trace( "Rewriting: " + model.getId() + " in place of: " + project.getKey()
-                         + "\n       to POM: " + pom );
+
+            logger.trace("Rewriting: {} in place of: {}\n       to POM: {}", model.getId(), project.getKey(), pom);
 
             write( project, pom, model );
 
@@ -301,7 +311,7 @@ public class PomIO
                 final File pom = pendingPoms.removeFirst();
                 seen.add( pom );
 
-                logger.debug( "PEEK: " + pom );
+                logger.debug("PEEK: {}", pom);
 
                 final PomPeek peek = new PomPeek( pom );
                 final ProjectVersionRef key = peek.getKey();
@@ -314,7 +324,8 @@ public class PomIO
                     final String relPath = peek.getParentRelativePath();
                     if ( relPath != null )
                     {
-                        logger.debug( "Found parent relativePath: " + relPath + " in pom: " + pom );
+                        logger.debug("Found parent relativePath: {} in pom: {}", relPath, pom);
+
                         File parent = new File( dir, relPath );
                         if ( parent.isDirectory() )
                         {
@@ -328,13 +339,14 @@ public class PomIO
                             && !pendingPoms.contains( parent ) )
                         {
                             topLevelParent = parent;
-                            logger.debug( "Possible top level parent " + parent );
+
+                            logger.debug("Possible top level parent {}", parent);
                             pendingPoms.add( parent );
                         }
                         else
                         {
-                            logger.debug( "Skipping reference to non-existent parent relativePath: '" + relPath
-                                + "' in: " + pom );
+                            logger.debug("Skipping reference to non-existent parent relativePath: '{}' in: {}",
+                                    relPath, pom);
                         }
                     }
 
@@ -343,7 +355,10 @@ public class PomIO
                     {
                         for ( final String module : modules )
                         {
-                            logger.debug( "Found module: " + module + " in pom: " + pom );
+                            if (logger.isDebugEnabled())
+                            {
+                                logger.debug("Found module: {} in pom: {}", module, pom);
+                            }
 
                             File modPom = new File( dir, module );
                             if ( modPom.isDirectory() )
@@ -358,14 +373,15 @@ public class PomIO
                             }
                             else
                             {
-                                logger.debug( "Skipping reference to non-existent module: '" + module + "' in: " + pom );
+                                logger.debug("Skipping reference to non-existent module: '{}' in: {}", module, pom);
                             }
                         }
                     }
                 }
                 else
                 {
-                    logger.debug( "Skipping " + pom + " as its a template file." );
+                    logger.debug( "Skipping {} as its a template file.", pom);
+
                 }
             }
 
@@ -378,7 +394,7 @@ public class PomIO
                 if ( p.getPom()
                       .equals( topLevelParent ) )
                 {
-                    logger.debug( "Setting top level parent to " + p.getPom() + " :: " + p.getKey() );
+                    logger.debug("Setting top level parent to {} :: {}", p.getPom(), p.getKey());
                     p.setInheritanceRoot( true );
                 }
             }
@@ -388,7 +404,9 @@ public class PomIO
                 if ( p.getParentKey() == null ||
                      ! seenThisParent(projectrefs, p.getParentKey()))
                 {
-                    logger.debug( "Found a standalone pom " + p.getPom() + " :: " + p.getKey() );
+
+                    logger.debug( "Found a standalone pom {} :: {}", p.getPom(), p.getKey() );
+
                     p.setInheritanceRoot( true );
                 }
             }

--- a/io/src/main/java/org/commonjava/maven/ext/io/resolver/MavenLocationExpander.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/resolver/MavenLocationExpander.java
@@ -91,8 +91,9 @@ public class MavenLocationExpander
         addSettingsProfileRepositoriesTo( locs, settings, activeProfiles, mirrorSelector );
         addRequestRepositoriesTo( locs, artifactRepositories, settings, mirrorSelector );
 
-        if ( locs.size() > 0 )
-            logger.debug( "Configured to use Maven locations:\n  {}", new JoinString( "\n  ", locs ) );
+        if ( locs.size() > 0 && logger.isDebugEnabled()) {
+            logger.debug("Configured to use Maven locations:\n  {}", new JoinString("\n  ", locs));
+        }
         this.locations = new ArrayList<>( locs );
     }
 
@@ -241,7 +242,10 @@ public class MavenLocationExpander
             expandSingle( loc, result );
         }
 
-        logger.debug( "Expanded to:\n {}", new JoinString( "\n  ", result ) );
+        if (logger.isDebugEnabled()) {
+            logger.debug("Expanded to:\n {}", new JoinString("\n  ", result));
+        }
+
         return result;
     }
 
@@ -262,7 +266,10 @@ public class MavenLocationExpander
             }
         }
 
-        logger.debug( "Expanded to:\n {}", new JoinString( "\n  ", result ) );
+        if (logger.isDebugEnabled())
+        {
+            logger.debug("Expanded to:\n {}", new JoinString("\n  ", result));
+        }
         return new VirtualResource( result );
     }
 


### PR DESCRIPTION
Cleaned up multiple logging statements to prevent concatenating strings unnecessarily and implement logging guards in a few occurrences where not doing so would result in associated methods being called even if the debug level was beyond the minimum used during the execution.