### PR TITLE
Treat HTTP status 503 as a recoverable since the server may be back in a bit

### DIFF
--- a/io/src/main/java/org/commonjava/maven/ext/io/rest/DefaultTranslator.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/rest/DefaultTranslator.java
@@ -71,7 +71,7 @@ public class DefaultTranslator
 
     private final ListingBlacklistMapper lbm;
 
-    private final int RETRY_WAIT_DURATION = 30;
+    private int retryDuration = 30;
 
     /**
      * @param endpointUrl is the URL to talk to.
@@ -206,9 +206,9 @@ public class DefaultTranslator
                     if (task.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE)
                     {
                         logger.info("The DA server is unavailable. Waiting {} before splitting the tasks and retrying",
-                                RETRY_WAIT_DURATION);
+                                retryDuration);
 
-                        waitBeforeRetry(RETRY_WAIT_DURATION);
+                        waitBeforeRetry(retryDuration);
                     }
 
                     List<Task> tasks = task.split();
@@ -387,5 +387,13 @@ public class DefaultTranslator
         {
             return chunk.size();
         }
+    }
+
+    public int getRetryDuration() {
+        return retryDuration;
+    }
+
+    public void setRetryDuration(int retryDuration) {
+        this.retryDuration = retryDuration;
     }
 }

--- a/io/src/main/java/org/commonjava/maven/ext/io/rest/DefaultTranslator.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/rest/DefaultTranslator.java
@@ -20,6 +20,7 @@ import com.mashape.unirest.http.ObjectMapper;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.apache.commons.codec.binary.Base32;
+import org.apache.http.HttpStatus;
 import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.ext.common.util.ListUtils;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
@@ -68,6 +70,8 @@ public class DefaultTranslator
     private final int initialRestMinSize;
 
     private final ListingBlacklistMapper lbm;
+
+    private final int RETRY_WAIT_DURATION = 30;
 
     /**
      * @param endpointUrl is the URL to talk to.
@@ -136,6 +140,8 @@ public class DefaultTranslator
         return result;
     }
 
+
+
     /**
      * Translate the versions.
      * <pre>{@code
@@ -195,8 +201,16 @@ public class DefaultTranslator
             }
             else
             {
-                if ( task.canSplit() && task.getStatus() == 504)
+                if ( task.canSplit() && isRecoverable(task.getStatus()))
                 {
+                    if (task.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE)
+                    {
+                        logger.info("The DA server is unavailable. Waiting {} before splitting the tasks and retrying",
+                                RETRY_WAIT_DURATION);
+
+                        waitBeforeRetry(RETRY_WAIT_DURATION);
+                    }
+
                     List<Task> tasks = task.split();
 
                     logger.warn( "Failed to translate versions for task @{} due to {}, splitting and retrying. Chunk size was: {} and new chunk size {} in {} segments.",
@@ -227,6 +241,19 @@ public class DefaultTranslator
             }
         }
         return result;
+    }
+
+    private boolean isRecoverable(int httpErrorCode)
+    {
+        return httpErrorCode == HttpStatus.SC_GATEWAY_TIMEOUT || httpErrorCode == HttpStatus.SC_SERVICE_UNAVAILABLE;
+    }
+
+    private void waitBeforeRetry(int seconds) {
+        try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(seconds));
+        } catch (InterruptedException e) {
+
+        }
     }
 
     /**

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/HandleServiceUnavailableTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/HandleServiceUnavailableTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.ext.io.rest;
+
+import com.mashape.unirest.http.Unirest;
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.ext.io.rest.exception.RestException;
+import org.commonjava.maven.ext.io.rest.handler.SpyFailJettyHandler;
+import org.commonjava.maven.ext.io.rest.rule.MockServer;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+
+import static org.commonjava.maven.ext.io.rest.Translator.RestProtocol.CURRENT;
+import static org.commonjava.maven.ext.io.rest.VersionTranslatorTest.loadALotOfGAVs;
+import static org.junit.Assert.*;
+
+/**
+ * @author Jakub Senko <jsenko@redhat.com>
+ */
+@RunWith( Parameterized.class)
+public class HandleServiceUnavailableTest
+{
+    private static List<ProjectVersionRef> aLotOfGavs;
+
+    private DefaultTranslator versionTranslator;
+
+    private Translator.RestProtocol protocol;
+
+    @Parameterized.Parameters()
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList( new Object[][] { { CURRENT } } );
+    }
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private static SpyFailJettyHandler handler = new SpyFailJettyHandler();
+
+    @Rule
+    public MockServer mockServer = new MockServer( handler );
+
+    private static final Logger LOG = LoggerFactory.getLogger( HandleServiceUnavailableTest.class );
+
+    @BeforeClass
+    public static void startUp() throws IOException
+    {
+        aLotOfGavs = loadALotOfGAVs();
+        assertTrue( aLotOfGavs.size() >= 37 );
+    }
+
+    @Before
+    public void before()
+    {
+        LOG.info( "Executing test " + testName.getMethodName() );
+
+        handler.setStatusCode( HttpServletResponse.SC_SERVICE_UNAVAILABLE );
+        versionTranslator = new DefaultTranslator( mockServer.getUrl(), protocol, 0, Translator.CHUNK_SPLIT_COUNT,
+                                                   "", "" );
+    }
+
+    public HandleServiceUnavailableTest(Translator.RestProtocol protocol )
+    {
+        this.protocol = protocol;
+    }
+
+    @Test
+    public void testConnection()
+    {
+        try
+        {
+            Unirest.post( mockServer.getUrl() ).asString();
+        }
+        catch ( Exception e )
+        {
+            fail( "Failed to connect to server, exception message: " + e.getMessage() );
+        }
+    }
+
+    /**
+     * Ensures that the version translation does not fail upon receiving 503
+     * and follow the same behavior as that of a 504.
+     */
+    @Test
+    public void testTranslateVersionsCorrectSplit()
+    {
+        List<ProjectVersionRef> data = aLotOfGavs.subList( 0, 37 );
+        handler.getRequestData().clear();
+        try
+        {
+            // Decrease the wait time so that the test does not take too long
+            versionTranslator.setRetryDuration(5);
+            versionTranslator.translateVersions( data );
+            fail();
+        }
+        catch ( RestException ex )
+        {
+            // ok
+        }
+        List<List<Map<String, Object>>> requestData = handler.getRequestData();
+        // split 37 -> 9, 9, 9, 10
+        // split 9 -> 2, 2, 2, 3 (x3)
+        // split 10 -> 2, 2, 2, 4
+        // split 4 -> 1, 1, 1, 1
+        // 37, 9, 9, 9, 10, 2, 2, 2, 3, ..., 2, 2, 2, 4, 1, 1, 1, 1 -> total 21 chunks
+        // However, split fails after the 6th attempt
+        LOG.debug( requestData.toString() );
+        assertEquals( 6, requestData.size() );
+        assertEquals( 37, requestData.get( 0 ).size() );
+        for ( int i = 1; i < 4; i++ )
+            assertEquals( 9, requestData.get( i ).size() );
+        assertEquals( 10, requestData.get( 4 ).size() );
+        assertEquals( 2, requestData.get( 5 ).size() );
+
+        Set<Map<String, Object>> original = new HashSet<>();
+        original.addAll( requestData.get( 0 ) );
+
+        Set<Map<String, Object>> chunks = new HashSet<>();
+        for ( List<Map<String, Object>> e : requestData.subList( 1, 5 ) )
+        {
+            chunks.addAll( e );
+        }
+        assertEquals( original, chunks );
+    }
+}


### PR DESCRIPTION
This should improve the behavior when using DA servers that suffer from reliability issues and get restarted/bounced from time to time.