### PR TITLE
Overrides from file

### DIFF
--- a/cli/src/main/java/org/commonjava/maven/ext/cli/Cli.java
+++ b/cli/src/main/java/org/commonjava/maven/ext/cli/Cli.java
@@ -76,6 +76,7 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -186,6 +187,11 @@ public class Cli
         options.addOption( Option.builder( "" )
                 .longOpt( "report-dir" )
                 .desc( "Creates a report with all the alignment changes and saves to the given file" )
+                .numberOfArgs( 1 )
+                .build() );
+        options.addOption( Option.builder( "" )
+                .longOpt( "overrides-from-file" )
+                .desc( "Reads the overrides, in GAV format, one per-line, from a file" )
                 .numberOfArgs( 1 )
                 .build() );
 
@@ -304,6 +310,11 @@ public class Cli
                         session.getUserProperties().setProperty( key, config.getProperty(key) );
                     }
                 }
+            }
+
+            if (cmd.hasOption("overrides-from-file"))
+            {
+                loadOverridesFromFile(cmd);
             }
         }
         catch ( ManipulationException e )
@@ -431,6 +442,22 @@ public class Cli
             return 100;
         }
         return 0;
+    }
+
+    private void loadOverridesFromFile(CommandLine cmd) throws ManipulationException {
+        File file = new File(cmd.getOptionValue("overrides-from-file"));
+
+        try
+        {
+            List<String> lines = FileUtils.readLines(file, Charset.defaultCharset());
+            for (String line : lines) {
+                String kv[] = line.split("=");
+                session.getUserProperties().setProperty( "dependencyOverride." + kv[0], kv[1] );
+            }
+        } catch (IOException e)
+        {
+            throw new ManipulationException("Unable to read overrides file", e);
+        }
     }
 
     @SuppressWarnings( "deprecation" )

--- a/cli/src/main/java/org/commonjava/maven/ext/cli/Cli.java
+++ b/cli/src/main/java/org/commonjava/maven/ext/cli/Cli.java
@@ -55,6 +55,8 @@ import org.codehaus.plexus.component.repository.exception.ComponentLookupExcepti
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
 import org.commonjava.maven.atlas.ident.ref.InvalidRefException;
 import org.commonjava.maven.ext.common.ManipulationException;
+import org.commonjava.maven.ext.common.callbacks.ComparatorCallback;
+import org.commonjava.maven.ext.common.callbacks.FileReporter;
 import org.commonjava.maven.ext.common.model.SimpleScopedArtifactRef;
 import org.commonjava.maven.ext.core.ManipulationManager;
 import org.commonjava.maven.ext.core.ManipulationSession;
@@ -181,6 +183,11 @@ public class Cli
                                  .numberOfArgs( 2 )
                                  .desc( "XPath tester ( file : xpath )" )
                                  .build() );
+        options.addOption( Option.builder( "" )
+                .longOpt( "report-dir" )
+                .desc( "Creates a report with all the alignment changes and saves to the given file" )
+                .numberOfArgs( 1 )
+                .build() );
 
         CommandLineParser parser = new DefaultParser();
         CommandLine cmd;
@@ -394,6 +401,11 @@ public class Cli
             }
             else
             {
+                if (cmd.hasOption( "report-dir" )) {
+                    String dir = cmd.getOptionValue( "report-dir" );
+                    manipulationManager.getPostAlignmentCallbacks().add(new ComparatorCallback(new FileReporter(dir)));
+                }
+
                 manipulationManager.scanAndApply( session );
             }
         }

--- a/cli/src/main/java/org/commonjava/maven/ext/cli/Cli.java
+++ b/cli/src/main/java/org/commonjava/maven/ext/cli/Cli.java
@@ -189,7 +189,7 @@ public class Cli
                 .desc( "Creates a report with all the alignment changes and saves to the given file" )
                 .numberOfArgs( 1 )
                 .build() );
-        options.addOption( Option.builder( "" )
+        options.addOption( Option.builder()
                 .longOpt( "overrides-from-file" )
                 .desc( "Reads the overrides, in GAV format, one per-line, from a file" )
                 .numberOfArgs( 1 )

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -35,7 +35,7 @@
       <pattern>%mdc{LOG-CONTEXT}%logger{0} %msg%n</pattern>
     </encoder>
   </appender>
-  <logger name="org.commonjava.maven.ext.common.util.ProjectComparator" level="INFO" additivity="false">
+  <logger name="org.commonjava.maven.ext.common.callbacks.ComparatorCallback" level="INFO" additivity="false">
     <appender-ref ref="COMPARATOR" />
   </logger>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -75,6 +75,10 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/common/src/main/java/org/commonjava/maven/ext/common/callbacks/Callback.java
+++ b/common/src/main/java/org/commonjava/maven/ext/common/callbacks/Callback.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.commonjava.maven.ext.common.callbacks;
+
+public interface Callback {
+}

--- a/common/src/main/java/org/commonjava/maven/ext/common/callbacks/ComparatorUtils.java
+++ b/common/src/main/java/org/commonjava/maven/ext/common/callbacks/ComparatorUtils.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (opiske@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.commonjava.maven.ext.common.callbacks;
+
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.ext.common.model.Project;
+
+/**
+ * Utilities to compare artifacts, projects and versions.
+ */
+public class ComparatorUtils {
+
+    /**
+     * Checks if 2 plugin artifacts are the same
+     * @param originalPVR original plugin artifact
+     * @param newPVR new plugin artifact
+     * @return true if equals or false otherwise
+     */
+    public static boolean samePluginArtifact(final ProjectVersionRef originalPVR, final ProjectVersionRef newPVR) {
+        if (newPVR.getGroupId().equals(originalPVR.getGroupId()))
+        {
+            if (newPVR.getArtifactId().equals(originalPVR.getArtifactId()))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if 2 projects are the same
+     * @param originalProject original project
+     * @param newProject new project to check
+     * @return true if equals or false otherwise
+     */
+    public static boolean sameProject(final Project originalProject, final Project newProject) {
+        if (newProject.getArtifactId().equals(originalProject.getArtifactId()))
+        {
+            if (newProject.getGroupId().equals(originalProject.getGroupId()))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Checks if 2 artifacts are the same
+     * @param originalArtifact the original artifact
+     * @param newArtifact new artifact
+     * @return true if equals or false otherwise
+     */
+    public static boolean sameArtifact(final ArtifactRef originalArtifact, final ArtifactRef newArtifact) {
+        if (newArtifact.getGroupId().equals(originalArtifact.getGroupId()))
+        {
+            if (newArtifact.getArtifactId().equals(originalArtifact.getArtifactId()))
+            {
+                if (newArtifact.getType().equals(originalArtifact.getType()))
+                {
+                    if (StringUtils.equals(newArtifact.getClassifier(), originalArtifact.getClassifier()))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Checks if the versions are the same
+     * @param originalArtifact the original artifact
+     * @param newArtifact new artifact
+     * @param <T>
+     * @return true if equals or false otherwise
+     */
+    public static <T extends ProjectVersionRef> boolean sameVersion(final T originalArtifact, final T newArtifact) {
+        return newArtifact.getVersionString().equals( originalArtifact.getVersionString());
+    }
+
+    /**
+     * Given a pair of key/values that represent the new and the old project, check if they have changed
+     * @param nKey the property key from the new project
+     * @param nValue the property value from the new project
+     * @param oKey the property key from the old project
+     * @param oValue the property value from the old project
+     * @return true if they are different (ie.: changed) or false otherwise
+     */
+    public static boolean propertyChanged(Object nKey, Object nValue, Object oKey, Object oValue) {
+        return oKey != null && oKey.equals(nKey) && oValue != null && !oValue.equals(nValue);
+    }
+
+}

--- a/common/src/main/java/org/commonjava/maven/ext/common/callbacks/FileReporter.java
+++ b/common/src/main/java/org/commonjava/maven/ext/common/callbacks/FileReporter.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (opiske@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.ext.common.callbacks;
+
+import org.apache.commons.io.FileUtils;
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.ext.common.ManipulationException;
+import org.commonjava.maven.ext.common.model.Project;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+public class FileReporter extends PrintableReport {
+    private static final String ALIGNED_DEP_EXT = ".dependencies";
+    private static final String NON_ALIGNED_DEP_EXT = ".na-dependencies";
+
+    private File outputDir;
+
+    public FileReporter(String outputDir) {
+        this(new File(outputDir));
+    }
+
+    public FileReporter(File outputDir) {
+        this.outputDir = outputDir;
+
+        outputDir.mkdirs();
+    }
+
+    private String getFormattedGAV(Project originalProject) {
+        return originalProject.getGroupId() + ":" + originalProject.getArtifactId() + ":" + originalProject.getVersion();
+    }
+
+    private void saveUpdatedProjectInformation() throws ManipulationException {
+        File outputFile = new File(outputDir, getNewProject().getArtifactId() + ".version");
+
+        final String origProj = getFormattedGAV(getOriginalProject());
+        final String newProj = getFormattedGAV(getNewProject());
+
+        try
+        {
+            FileUtils.writeStringToFile(outputFile, String.format("%s=%s", origProj, newProj), Charset.defaultCharset());
+        } catch (IOException e)
+        {
+            throw new ManipulationException("Unable to save report", e);
+        }
+    }
+
+    private void printDependencies(ComparatorCallback.Type type, StringBuffer sb) {
+        List<ChangedVersion<?>> changedVersions = getChangedVersions().get(type);
+
+        if (changedVersions != null)
+        {
+            changedVersions.forEach(k ->
+                    sb.append(String.format("%s;%s;%s\n", type, k.originalArtifact, k.newArtifact)));
+        }
+    }
+
+    private void printNonAlignedDependencies(ComparatorCallback.Type type, StringBuffer sb) {
+        List<? extends ProjectVersionRef> changedVersions = getNonAligned().get(type);
+
+        if (changedVersions != null)
+        {
+            changedVersions.forEach(k ->
+                    sb.append(String.format("%s;%s\n", type, k)));
+        }
+    }
+
+    private void saveDependencies(String extension, BiConsumer<ComparatorCallback.Type, StringBuffer> printer) throws ManipulationException {
+        StringBuffer sb = new StringBuffer();
+
+        try
+        {
+            File outputFile = new File(outputDir, getNewProject().getArtifactId() + extension);
+
+            printer.accept(ComparatorCallback.Type.DEPENDENCIES, sb);
+            printer.accept(ComparatorCallback.Type.MANAGED_DEPENDENCIES, sb);
+            printer.accept(ComparatorCallback.Type.PLUGINS, sb);
+            printer.accept(ComparatorCallback.Type.MANAGED_PLUGINS, sb);
+            printer.accept(ComparatorCallback.Type.PROFILE_DEPENDENCIES, sb);
+            printer.accept(ComparatorCallback.Type.PROFILE_MANAGED_DEPENDENCIES, sb);
+
+            FileUtils.writeStringToFile(outputFile, sb.toString(), Charset.defaultCharset());
+        } catch (IOException e) {
+            throw new ManipulationException("Unable to save report", e);
+        }
+    }
+
+
+    @Override
+    public void flush() throws ManipulationException {
+        saveUpdatedProjectInformation();
+        saveDependencies(ALIGNED_DEP_EXT, this::printDependencies);
+        saveDependencies(NON_ALIGNED_DEP_EXT, this::printNonAlignedDependencies);
+    }
+}

--- a/common/src/main/java/org/commonjava/maven/ext/common/callbacks/LogReporter.java
+++ b/common/src/main/java/org/commonjava/maven/ext/common/callbacks/LogReporter.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (opiske@redhat.com)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.commonjava.maven.ext.common.callbacks;
+
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+public class LogReporter extends PrintableReport {
+    private static final Logger logger = LoggerFactory.getLogger(LogReporter.class);
+
+    public void flush()
+    {
+        logger.info("------------------- project {} ", getNewProject().getKey().asProjectRef());
+        if (isProjectChanged()) {
+            logger.info("\tProject version : {} ---> {}\n", getOriginalProject().getVersion(),
+                    getNewProject().getVersion());
+        }
+
+        printDependencies(ComparatorCallback.Type.DEPENDENCIES);
+        printNonAlignedDependencies(ComparatorCallback.Type.DEPENDENCIES);
+        printDependencies(ComparatorCallback.Type.MANAGED_DEPENDENCIES);
+        printNonAlignedDependencies(ComparatorCallback.Type.MANAGED_DEPENDENCIES);
+        pageBreak();
+        printDependencies(ComparatorCallback.Type.PLUGINS);
+        printNonAlignedDependencies(ComparatorCallback.Type.PLUGINS);
+        printDependencies(ComparatorCallback.Type.MANAGED_PLUGINS);
+        printNonAlignedDependencies(ComparatorCallback.Type.MANAGED_PLUGINS);
+
+        getChangedProperties().forEach((k, v) ->
+                logger.info("\tProperty : key {} ; value {} ---> {}", k, v.originalValue, v.newValue));
+        pageBreak();
+        getChangedProfileProperties().forEach((k, v) ->
+                logger.info("\tProfile Property : key {} ; value {} ---> {}", k, v.originalValue, v.newValue));
+        pageBreak();
+
+        printDependencies(ComparatorCallback.Type.PROFILE_DEPENDENCIES);
+        printNonAlignedDependencies(ComparatorCallback.Type.PROFILE_MANAGED_DEPENDENCIES);
+        printDependencies(ComparatorCallback.Type.PROFILE_DEPENDENCIES);
+        printNonAlignedDependencies(ComparatorCallback.Type.PROFILE_MANAGED_DEPENDENCIES);
+
+    }
+
+    private void printDependencies(ComparatorCallback.Type type) {
+        List<ChangedVersion<?>> changedVersions = getChangedVersions().get(type);
+
+        if (changedVersions != null)
+        {
+            changedVersions.forEach(k ->
+                    logger.info("\t{} : {} --> {} ", type, k.originalArtifact, k.newArtifact));
+        }
+    }
+
+    private void pageBreak() {
+        logger.info("");
+    }
+
+
+    protected void printNonAlignedDependencies(ComparatorCallback.Type type) {
+        List<? extends ProjectVersionRef> nonAlignedList = getNonAligned().get(type);
+
+        if (nonAlignedList != null)
+        {
+            pageBreak();
+            nonAlignedList.forEach(k -> logger.info("\tNon-Aligned {} : {} ", type, k));
+        }
+    }
+
+
+    public void reset() {
+        super.reset();
+        logger.info("");
+    }
+}

--- a/common/src/main/java/org/commonjava/maven/ext/common/callbacks/PostAlignmentCallback.java
+++ b/common/src/main/java/org/commonjava/maven/ext/common/callbacks/PostAlignmentCallback.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+ * Copyright (C) 2019 Red Hat, Inc. (opiske@redhat.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,5 +23,13 @@ import org.commonjava.maven.ext.common.session.MavenSessionHandler;
 import java.util.List;
 
 public interface PostAlignmentCallback extends Callback {
+
+    /**
+     * Executes a callback after the alignment is complete
+     * @param session the Maven session handler
+     * @param originalProjects the original unmodified project
+     * @param newProjects the new modified project
+     * @throws ManipulationException
+     */
     void call(MavenSessionHandler session, List<Project> originalProjects, List<Project> newProjects) throws ManipulationException;
 }

--- a/common/src/main/java/org/commonjava/maven/ext/common/callbacks/PostAlignmentCallback.java
+++ b/common/src/main/java/org/commonjava/maven/ext/common/callbacks/PostAlignmentCallback.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.commonjava.maven.ext.common.callbacks;
+
+import org.commonjava.maven.ext.common.ManipulationException;
+import org.commonjava.maven.ext.common.model.Project;
+import org.commonjava.maven.ext.common.session.MavenSessionHandler;
+
+import java.util.List;
+
+public interface PostAlignmentCallback extends Callback {
+    void call(MavenSessionHandler session, List<Project> originalProjects, List<Project> newProjects) throws ManipulationException;
+}

--- a/common/src/main/java/org/commonjava/maven/ext/common/callbacks/PrintableReport.java
+++ b/common/src/main/java/org/commonjava/maven/ext/common/callbacks/PrintableReport.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) 2012 Red Hat, Inc. (jcasey@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.commonjava.maven.ext.common.callbacks;
+
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.ext.common.ManipulationException;
+import org.commonjava.maven.ext.common.model.Project;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+abstract class PrintableReport implements Report {
+    private Project newProject;
+    private Project originalProject;
+    private boolean projectChanged = false;
+    private HashMap<Object, ChangedProperty> changedProperties = new HashMap<>();
+    private HashMap<Object, ChangedProperty> changedProfileProperties = new HashMap<>();
+    private HashMap<ComparatorCallback.Type, List<ChangedVersion<?>>> changedVersions = new HashMap<>();
+    private HashMap<ComparatorCallback.Type, List<? extends ProjectVersionRef>> nonAligned = new HashMap<>();
+
+    class ChangedProperty {
+        Object originalValue;
+        Object newValue;
+
+        public ChangedProperty(Object originalValue, Object newValue) {
+            this.originalValue = originalValue;
+            this.newValue = newValue;
+        }
+    }
+
+    class ChangedVersion<T> {
+        T originalArtifact;
+        T newArtifact;
+
+        public ChangedVersion(T originalArtifact, T newArtifact) {
+            this.originalArtifact = originalArtifact;
+            this.newArtifact = newArtifact;
+        }
+    }
+
+    public void init(final Project newProject, final Project originalProject) {
+
+        this.newProject = newProject;
+        this.originalProject = originalProject;
+    }
+
+    public abstract void flush() throws ManipulationException;
+
+    public void projectVersionChanged() {
+        projectChanged = true;
+    }
+
+    private void propertyChanged(final Object nValue, final Object oKey, final Object oValue) {
+        changedProperties.put(oKey, new ChangedProperty(oValue, nValue));
+    }
+
+    public void propertyChanged(final Map.Entry<Object, Object> newProperty, final Map.Entry<Object, Object> oldProperty) {
+        propertyChanged(newProperty.getValue(), oldProperty.getKey(), oldProperty.getValue());
+    }
+
+    private void profilePropertyChanged(final Object nValue, final Object oKey, final Object oValue) {
+        changedProfileProperties.put(oKey, new ChangedProperty(oValue, nValue));
+
+    }
+
+    public void profilePropertyChanged(final Map.Entry<Object, Object> newProperty, final Map.Entry<Object, Object> oldProperty) {
+        profilePropertyChanged(newProperty.getValue(), oldProperty.getKey(), oldProperty.getValue());
+    }
+
+    public <T extends ProjectVersionRef> void reportVersionChanged(ComparatorCallback.Type type, T originalArtifact, T newArtifact) {
+        List<ChangedVersion<?>> artifactsList = changedVersions.get(type);
+        if (artifactsList == null) {
+            artifactsList = new ArrayList<>();
+        }
+
+        artifactsList.add(new ChangedVersion<T>(originalArtifact, newArtifact));
+        changedVersions.put(type, artifactsList);
+    }
+
+    public <T extends ProjectVersionRef> void reportNonAligned(ComparatorCallback.Type type, T nonAlignedArtifact) {
+        List<T> nonAlignedSet = (List<T>) nonAligned.get(type);
+
+        if (nonAlignedSet == null) {
+            nonAlignedSet = new ArrayList<>();
+        }
+
+        nonAlignedSet.add(nonAlignedArtifact);
+
+        nonAligned.put(type, nonAlignedSet);
+    }
+
+    protected Project getNewProject() {
+        return newProject;
+    }
+
+    protected Project getOriginalProject() {
+        return originalProject;
+    }
+
+    protected boolean isProjectChanged() {
+        return projectChanged;
+    }
+
+    protected HashMap<Object, ChangedProperty> getChangedProperties() {
+        return changedProperties;
+    }
+
+    protected HashMap<Object, ChangedProperty> getChangedProfileProperties() {
+        return changedProfileProperties;
+    }
+
+    protected HashMap<ComparatorCallback.Type, List<ChangedVersion<?>>> getChangedVersions() {
+        return changedVersions;
+    }
+
+    protected HashMap<ComparatorCallback.Type, List<? extends ProjectVersionRef>> getNonAligned() {
+        return nonAligned;
+    }
+
+    public void reset() {
+        newProject = null;
+        originalProject = null;
+        projectChanged = false;
+        changedProperties.clear();
+        changedProfileProperties.clear();
+        changedVersions.clear();
+        nonAligned.clear();
+    }
+}

--- a/common/src/main/java/org/commonjava/maven/ext/common/callbacks/Report.java
+++ b/common/src/main/java/org/commonjava/maven/ext/common/callbacks/Report.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc. (opiske@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.commonjava.maven.ext.common.callbacks;
+
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.ext.common.ManipulationException;
+import org.commonjava.maven.ext.common.model.Project;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An interface that allows the implementation of reports based on the comparison of projects
+ */
+public interface Report {
+    /**
+     * Initializes the report
+     * @param newProject the new project
+     */
+    void init(final Project newProject, final Project originalProject);
+
+    /**
+     * Reports a project version change
+     */
+    void projectVersionChanged() throws ManipulationException;
+
+    /**
+     * Reports a property change
+     * @param newProperty the new property
+     * @param oldProperty the original (old) property
+     */
+    void propertyChanged(Map.Entry<Object, Object> newProperty, Map.Entry<Object, Object> oldProperty);
+
+    /**
+     * Reports property changed within a profile
+     * @param newProperty the new property
+     * @param oldProperty the original (old) property
+     */
+    void profilePropertyChanged(Map.Entry<Object, Object> newProperty, Map.Entry<Object, Object> oldProperty);
+
+    /**
+     * Reports a version change
+     * @param type artifact type
+     * @param originalArtifact original artifact
+     * @param newArtifact new artifact
+     * @param <T>
+     */
+    <T extends ProjectVersionRef> void reportVersionChanged(ComparatorCallback.Type type, T originalArtifact, T newArtifact);
+
+
+    /**
+     * Reports non-aligned dependencies
+     * @param type
+     * @param nonAligned
+     * @param <T>
+     */
+    <T extends ProjectVersionRef> void reportNonAligned(ComparatorCallback.Type type, T nonAligned);
+
+
+    /**
+     * Flushes the report
+     */
+    void flush() throws ManipulationException;
+
+    /**
+     * Reset
+     */
+    void reset();
+}

--- a/core/src/main/java/org/commonjava/maven/ext/core/ManipulationManager.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/ManipulationManager.java
@@ -30,7 +30,7 @@ import org.apache.maven.project.ProjectBuilder;
 import org.commonjava.maven.ext.common.ManipulationException;
 import org.commonjava.maven.ext.common.model.GAV;
 import org.commonjava.maven.ext.common.model.Project;
-import org.commonjava.maven.ext.common.util.ProjectComparator;
+import org.commonjava.maven.ext.common.callbacks.ComparatorCallback;
 import org.commonjava.maven.ext.core.impl.Manipulator;
 import org.commonjava.maven.ext.core.state.CommonState;
 import org.commonjava.maven.ext.core.state.State;
@@ -192,7 +192,9 @@ public class ManipulationManager
                 throw new ManipulationException( "Marker/result file creation failed", e );
             }
 
-            ProjectComparator.compareProjects( session, originalProjects, currentProjects );
+            ComparatorCallback comparatorCallback = new ComparatorCallback();
+
+            comparatorCallback.call( session, originalProjects, currentProjects );
         }
 
         // Ensure shutdown of GalleyInfrastructure Executor Service

--- a/core/src/test/java/org/commonjava/maven/ext/core/util/ComparatorCallbackTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/core/util/ComparatorCallbackTest.java
@@ -22,7 +22,7 @@ import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.commonjava.maven.ext.common.model.Project;
-import org.commonjava.maven.ext.common.util.ProjectComparator;
+import org.commonjava.maven.ext.common.callbacks.ComparatorCallback;
 import org.commonjava.maven.ext.core.ManipulationSession;
 import org.commonjava.maven.ext.core.fixture.TestUtils;
 import org.commonjava.maven.ext.core.state.CommonState;
@@ -41,7 +41,7 @@ import java.util.Properties;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 
-public class ProjectComparatorTest
+public class ComparatorCallbackTest
 {
     private static final String RESOURCE_BASE = "properties/";
 
@@ -63,7 +63,9 @@ public class ProjectComparatorTest
         List<Project> projectOriginal = pomIO.parseProject( projectroot );
         List<Project> projectNew = pomIO.parseProject( projectroot );
 
-        ProjectComparator.compareProjects( session, projectOriginal, projectNew );
+        ComparatorCallback comparatorCallback = new ComparatorCallback();
+
+        comparatorCallback.call( session, projectOriginal, projectNew );
 
         assertFalse( systemOutRule.getLog().contains( "-->" ) );
     }
@@ -92,8 +94,9 @@ public class ProjectComparatorTest
             }
         } );
 
-        ProjectComparator.compareProjects( session, projectOriginal, projectNew );
+        ComparatorCallback comparatorCallback = new ComparatorCallback();
 
+        comparatorCallback.call( session, projectOriginal, projectNew );
 
         assertTrue( systemOutRule.getLog().contains( "Managed dependencies :" ) );
         assertTrue( systemOutRule.getLog().contains( "Project version :" ) );

--- a/core/src/test/java/org/commonjava/maven/ext/core/util/ComparatorCallbackTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/core/util/ComparatorCallbackTest.java
@@ -21,6 +21,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
+import org.commonjava.maven.ext.common.callbacks.LogReporter;
 import org.commonjava.maven.ext.common.model.Project;
 import org.commonjava.maven.ext.common.callbacks.ComparatorCallback;
 import org.commonjava.maven.ext.core.ManipulationSession;
@@ -63,7 +64,7 @@ public class ComparatorCallbackTest
         List<Project> projectOriginal = pomIO.parseProject( projectroot );
         List<Project> projectNew = pomIO.parseProject( projectroot );
 
-        ComparatorCallback comparatorCallback = new ComparatorCallback();
+        ComparatorCallback comparatorCallback = new ComparatorCallback(new LogReporter());
 
         comparatorCallback.call( session, projectOriginal, projectNew );
 
@@ -94,7 +95,7 @@ public class ComparatorCallbackTest
             }
         } );
 
-        ComparatorCallback comparatorCallback = new ComparatorCallback();
+        ComparatorCallback comparatorCallback = new ComparatorCallback(new LogReporter());
 
         comparatorCallback.call( session, projectOriginal, projectNew );
 

--- a/core/src/test/java/org/commonjava/maven/ext/core/util/PropertiesUtilsTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/core/util/PropertiesUtilsTest.java
@@ -24,7 +24,7 @@ import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.commonjava.maven.ext.common.ManipulationException;
 import org.commonjava.maven.ext.common.model.Project;
-import org.commonjava.maven.ext.common.util.ProjectComparator;
+import org.commonjava.maven.ext.common.callbacks.ComparatorCallback;
 import org.commonjava.maven.ext.common.util.PropertyResolver;
 import org.commonjava.maven.ext.core.ManipulationSession;
 import org.commonjava.maven.ext.core.fixture.TestUtils;
@@ -276,12 +276,14 @@ public class PropertiesUtilsTest
 
         List<Project> newprojects = pomIO.parseProject( projectroot );
 
-        ProjectComparator.compareProjects( session, projects, newprojects );
+        ComparatorCallback comparatorCallback = new ComparatorCallback();
 
-        assertTrue( systemRule.getLog().contains( "[main] INFO  o.c.m.e.c.util.ProjectComparator - ------------------- project org.infinispan:infinispan-bom \n"
-                                                      + "[main] INFO  o.c.m.e.c.util.ProjectComparator - \n"
-                                                      + "[main] INFO  o.c.m.e.c.util.ProjectComparator - \n"
-                                                      + "[main] INFO  o.c.m.e.c.util.ProjectComparator - \n" ) );
+        comparatorCallback.call( session, projects, newprojects );
+
+        assertTrue( systemRule.getLog().contains( "[main] INFO  o.c.m.e.c.c.ComparatorCallback - ------------------- project org.infinispan:infinispan-bom \n"
+                                                      + "[main] INFO  o.c.m.e.c.c.ComparatorCallback - \n"
+                                                      + "[main] INFO  o.c.m.e.c.c.ComparatorCallback - \n"
+                                                      + "[main] INFO  o.c.m.e.c.c.ComparatorCallback - \n" ) );
     }
 
 

--- a/core/src/test/java/org/commonjava/maven/ext/core/util/PropertiesUtilsTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/core/util/PropertiesUtilsTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.model.Model;
 import org.codehaus.plexus.DefaultPlexusContainer;
 import org.codehaus.plexus.PlexusContainer;
 import org.commonjava.maven.ext.common.ManipulationException;
+import org.commonjava.maven.ext.common.callbacks.LogReporter;
 import org.commonjava.maven.ext.common.model.Project;
 import org.commonjava.maven.ext.common.callbacks.ComparatorCallback;
 import org.commonjava.maven.ext.common.util.PropertyResolver;
@@ -276,14 +277,16 @@ public class PropertiesUtilsTest
 
         List<Project> newprojects = pomIO.parseProject( projectroot );
 
-        ComparatorCallback comparatorCallback = new ComparatorCallback();
+        ComparatorCallback comparatorCallback = new ComparatorCallback(new LogReporter());
 
         comparatorCallback.call( session, projects, newprojects );
 
-        assertTrue( systemRule.getLog().contains( "[main] INFO  o.c.m.e.c.c.ComparatorCallback - ------------------- project org.infinispan:infinispan-bom \n"
-                                                      + "[main] INFO  o.c.m.e.c.c.ComparatorCallback - \n"
-                                                      + "[main] INFO  o.c.m.e.c.c.ComparatorCallback - \n"
-                                                      + "[main] INFO  o.c.m.e.c.c.ComparatorCallback - \n" ) );
+        String log = systemRule.getLog();
+
+        assertTrue( log.contains( "[main] INFO  o.c.m.e.common.callbacks.LogReporter - ------------------- project org.infinispan:infinispan-bom \n"
+                                                      + "[main] INFO  o.c.m.e.common.callbacks.LogReporter - \n"
+                                                      + "[main] INFO  o.c.m.e.common.callbacks.LogReporter - \n"
+                                                      + "[main] INFO  o.c.m.e.common.callbacks.LogReporter - \n") );
     }
 
 

--- a/integration-test/src/main/java/org/commonjava/maven/ext/integrationtest/TestUtils.java
+++ b/integration-test/src/main/java/org/commonjava/maven/ext/integrationtest/TestUtils.java
@@ -206,7 +206,7 @@ public class TestUtils
         Integer result = (Integer) executeMethod( cli, "run", new Object[]{arguments.toArray( new String[0] )} );
 
         // Close unirest client down to prevent any hanging.
-        // Unirest.shutdown();
+        // Unirest.reset();
 
         // This is a bit of a hack. The CLI, if log-to-file is enabled resets the logging. As we don't fork and run
         // in the same process this means we need to reset it back again. The benefit of not forking is a simpler test


### PR DESCRIPTION
This one depends on PR #640 and adds a functionality that allows it to read the overrides from a text file. The reason for this feature is that we have a very big pipeline. After every build, we update the list of overrides and put it into a text file containing a list of overrides that is passed as input arguments to PME. The file looks like this:: 

```-DdependencyOverride.org.apache.karaf.webconsole:org.apache.karaf.webconsole.instance@*=4.2.0.fuse-740006-myorg-00001 
-DdependencyOverride.org.apache.karaf.webconsole:webconsole@*=4.2.0.fuse-740006-myorg-00001 
-DdependencyOverride.org.apache.karaf.wrapper:org.apache.karaf.wrapper.core@*=4.2.0.fuse-740006-myorg-00001 
```

However, since our project is significantly complex and the overrides file got so big that we cannot pass it as arguments since it exceeds the number of arguments that can be passed. 

Although we know about using a BOM for the overrides, we prefer to use a text file because it is simpler and faster to generate.