### PR TITLE
Fix readModelsForManipulation call in PomIO.parseProject

### DIFF
--- a/io/src/main/java/org/commonjava/maven/ext/io/PomIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/PomIO.java
@@ -68,10 +68,17 @@ public class PomIO
     private static final Logger logger = LoggerFactory.getLogger( PomIO.class );
 
 
-    public List<Project> parseProject (final File pom) throws ManipulationException
+    public List<Project> parseProject( final File pom ) throws ManipulationException
     {
-        final List<PomPeek> peeked = peekAtPomHierarchy(pom);
-        return readModelsForManipulation( pom.getAbsoluteFile(), peeked );
+        final List<PomPeek> peeked = peekAtPomHierarchy( pom );
+        try
+        {
+            return readModelsForManipulation( pom.getCanonicalFile(), peeked );
+        }
+        catch ( IOException e )
+        {
+            throw new ManipulationException( "Error getting canonical file", e );
+        }
     }
 
     /**


### PR DESCRIPTION
The method readModelsForManipulation was passing
pom.getAbsoluteFile which could lead to failures later on in
cases where pom.getAbsoluteFile was not equal to
pom.getCanonicalFile.