### PR TITLE
Migrate to using go-offline-maven-plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install: |
 jobs:
   include:
     - stage: cache warmup
-      script: mvn dependency:go-offline -Prun-its
+      script: mvn de.qaware.maven:go-offline-maven-plugin:1.2.4:resolve-dependencies -Prun-its
 
     - stage: test
       os: linux


### PR DESCRIPTION
See https://github.com/qaware/go-offline-maven-plugin ; avoids issues with dependency:go-offline. Possible to use now https://github.com/qaware/go-offline-maven-plugin/issues/16 is fixed :-) 