### PR TITLE
Update to Galley 0.16.6

### DIFF
--- a/core/src/test/java/org/commonjava/maven/ext/core/groovy/BaseScriptTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/core/groovy/BaseScriptTest.java
@@ -173,7 +173,7 @@ public class BaseScriptTest
                                     .getDependencies()
                                     .stream()
                                     .filter( d -> d.getGroupId().equals( "org.commonjava.maven.galley" ) )
-                                    .filter( d -> d.getVersion().equals( "0.16.3" ) )
+                                    .filter( d -> d.getVersion().equals( "0.16.6" ) )
                                     .count() );
 
 

--- a/core/src/test/java/org/commonjava/maven/ext/core/util/ProjectComparatorTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/core/util/ProjectComparatorTest.java
@@ -61,7 +61,7 @@ public class ProjectComparatorTest
     public final TemporaryFolder temporaryFolder = new TemporaryFolder(  );
 
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();//.muteForSuccessfulTests();
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
 
     private final WildcardMap<ProjectVersionRef> map = new WildcardMap<>();
 
@@ -126,8 +126,8 @@ public class ProjectComparatorTest
         System.out.println (result);
 
         String jsonString = JSONUtils.jsonToString(json);
-        assertTrue( jsonString.contains( "org.commonjava.maven.galley:galley-maven:0.16.3\" : {" ) );
-        assertTrue( jsonString.contains( "\"version\" : \"0.16.3-redhat-1\"" ) );
+        assertTrue( jsonString.contains( "org.commonjava.maven.galley:galley-maven:0.16.6\" : {" ) );
+        assertTrue( jsonString.contains( "\"version\" : \"0.16.6-redhat-1\"" ) );
 
         System.out.println (jsonString);
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 
     <mavenVersion>3.5.0</mavenVersion>
     <atlasVersion>0.17.1</atlasVersion>
-    <galleyVersion>0.16.3</galleyVersion>
+    <galleyVersion>0.16.6</galleyVersion>
 
     <groovyVersion>2.5.7</groovyVersion>
     <unirestVersion>3.1.00</unirestVersion>


### PR DESCRIPTION
This is for https://github.com/project-ncl/bacon/pull/364 which updates Galley and therebye jhttpc to 1.9 - depending upon what @dwalluck needs. Note that this is **not** the latest Galley version, but versions after this have changed the Galley API and also have changed the Atlas dependency which changes the groupId for ProjectRef (for example). Therefore to minimise the change I have selected this version.