### PR TITLE
[NCL-6166] Add build type flags for DA calls

### DIFF
--- a/cli/src/test/java/org/commonjava/maven/ext/cli/CliTest.java
+++ b/cli/src/test/java/org/commonjava/maven/ext/cli/CliTest.java
@@ -358,7 +358,7 @@ public class CliTest
                 + "org.hamcrest:hamcrest-all:1.3                                                   jar                                     test                \n"
                 + "org.jacoco:jacoco-maven-plugin:0.8[.\\d+]+\\s+                                  maven-plugin                                                \n"
                 + "org.jboss.byteman:byteman-bmunit:4[.\\d+]+\\s+                                  jar                                     test                \n"
-                + "org.jboss.da:reports-model:1.7.0                                                jar                                     compile             \n"
+                + "org.jboss.da:reports-model:2.1.0.Api-1                                          jar                                     compile             \n"
                 + "org.jdom:jdom:1.1.3                                                             jar                                     compile             \n"
                 + "org.projectlombok:lombok:1.[.\\d+]+\\s+                                         jar                                     provided            \n"
                 + "org.projectlombok:lombok-maven-plugin:1.[.\\d+]+\\s+                            maven-plugin                                                \n"

--- a/core/src/main/java/org/commonjava/maven/ext/core/state/RESTState.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/state/RESTState.java
@@ -41,6 +41,12 @@ public class RESTState implements State
     public static final String REST_REPO_GROUP = "restRepositoryGroup";
 
     @ConfigValue( docIndex = "dep-manip.html#rest-endpoint" )
+    public static final String REST_BREW_PULL_ACTIVE = "restBrewPullActive";
+
+    @ConfigValue( docIndex = "dep-manip.html#rest-endpoint" )
+    public static final String REST_MODE = "restMode";
+
+    @ConfigValue( docIndex = "dep-manip.html#rest-endpoint" )
     public static final String REST_MAX_SIZE = "restMaxSize";
 
     @ConfigValue( docIndex = "dep-manip.html#rest-endpoint" )
@@ -76,6 +82,7 @@ public class RESTState implements State
         initialise( session.getUserProperties() );
     }
 
+    @Override
     public void initialise( Properties userProps )
     {
         final VersioningState vState = session.getState( VersioningState.class );
@@ -84,6 +91,8 @@ public class RESTState implements State
         restSuffixAlign = Boolean.parseBoolean( userProps.getProperty( REST_SUFFIX, "true" ) );
 
         String repositoryGroup = userProps.getProperty( REST_REPO_GROUP, "" );
+        Boolean brewPullActive = Boolean.parseBoolean( userProps.getProperty( REST_BREW_PULL_ACTIVE ) );
+        String mode = userProps.getProperty( REST_MODE );
         int restMaxSize = Integer.parseInt( userProps.getProperty( REST_MAX_SIZE, "-1" ) );
         int restMinSize = Integer.parseInt( userProps.getProperty( REST_MIN_SIZE,
                                                                    String.valueOf( DefaultTranslator.CHUNK_SPLIT_COUNT ) ) );
@@ -95,8 +104,9 @@ public class RESTState implements State
         int restRetryDuration = Integer.parseInt( userProps.getProperty( REST_RETRY_DURATION_SEC,
                                                                          String.valueOf( DefaultTranslator.RETRY_DURATION_SEC ) ) );
 
-        restEndpoint = new DefaultTranslator( restURL, restMaxSize, restMinSize, repositoryGroup, vState.getIncrementalSerialSuffix(),
-                                              restHeaders, restConnectionTimeout, restSocketTimeout, restRetryDuration );
+        restEndpoint = new DefaultTranslator( restURL, restMaxSize, restMinSize, repositoryGroup, brewPullActive, mode,
+                                              vState.getIncrementalSerialSuffix(), restHeaders, restConnectionTimeout,
+                                              restSocketTimeout, restRetryDuration );
     }
 
     /**

--- a/io/src/main/java/org/commonjava/maven/ext/io/rest/DefaultTranslator.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/rest/DefaultTranslator.java
@@ -76,6 +76,10 @@ public class DefaultTranslator
 
     private final String repositoryGroup;
 
+    private final Boolean brewPullActive;
+
+    private final String mode;
+
     private final String incrementalSerialSuffix;
 
     private final Map<String, String> restHeaders;
@@ -101,15 +105,21 @@ public class DefaultTranslator
      * @param endpointUrl is the URL to talk to.
      * @param restMaxSize initial (maximum) size of the rest call; if zero will send everything.
      * @param restMinSize minimum size for the call
-     * @param repositoryGroup the group to pass to the endpoint.
+     * @param repositoryGroup the group to pass to the endpoint, still can be used, but is replaced by
+     *        brewPullActive flag and mode when used in combination with DA 2.1 and above
+     * @param brewPullActive flag saying if brew pull should be used for version retrieval
+     * @param mode lookup mode, either STANDARD (default if empty) or SERVICE
      * @param incrementalSerialSuffix the suffix to pass to the endpoint.
      * @param restHeaders the headers to pass to the endpoint
      */
     public DefaultTranslator( String endpointUrl, int restMaxSize, int restMinSize, String repositoryGroup,
-                              String incrementalSerialSuffix, Map<String, String> restHeaders,
-                              int restConnectionTimeout, int restSocketTimeout, int restRetryDuration )
+                              Boolean brewPullActive, String mode, String incrementalSerialSuffix,
+                              Map<String, String> restHeaders, int restConnectionTimeout, int restSocketTimeout,
+                              int restRetryDuration )
     {
         this.repositoryGroup = repositoryGroup;
+        this.brewPullActive = brewPullActive;
+        this.mode = mode;
         this.incrementalSerialSuffix = incrementalSerialSuffix;
         this.endpointUrl = endpointUrl + ( isNotBlank( endpointUrl ) ? endpointUrl.endsWith( "/" ) ? "" : "/" : "");
         this.initialRestMaxSize = restMaxSize;
@@ -125,13 +135,17 @@ public class DefaultTranslator
      * @param restMaxSize initial (maximum) size of the rest call; if zero will send everything.
      * @param restMinSize minimum size for the call
      * @param repositoryGroup the group to pass to the endpoint.
+     * @param brewPullActive flag saying if brew pull should be used for version retrieval
+     * @param mode lookup mode, either STANDARD (default if empty) or SERVICE
      * @param incrementalSerialSuffix the suffix to pass to the endpoint.
      */
-    public DefaultTranslator( String endpointUrl, int restMaxSize, int restMinSize, String repositoryGroup, String incrementalSerialSuffix,
+    public DefaultTranslator( String endpointUrl, int restMaxSize, int restMinSize, String repositoryGroup,
+                              Boolean brewPullActive, String mode, String incrementalSerialSuffix,
                               int restConnectionTimeout, int restSocketTimeout, int restRetryDuration)
     {
-        this ( endpointUrl, restMaxSize, restMinSize, repositoryGroup, incrementalSerialSuffix,
-               Collections.emptyMap(), restConnectionTimeout, restSocketTimeout, restRetryDuration );
+        this ( endpointUrl, restMaxSize, restMinSize, repositoryGroup, brewPullActive, mode,
+               incrementalSerialSuffix, Collections.emptyMap(), restConnectionTimeout, restSocketTimeout,
+               restRetryDuration );
     }
 
     private void partition(List<ProjectVersionRef> projects, Queue<Task> queue) {
@@ -302,6 +316,7 @@ public class DefaultTranslator
      * There may be a lot of them, possibly causing timeouts or other issues.
      * This is mitigated by splitting them into smaller chunks when an error occurs and retrying.
      */
+    @Override
     public Map<ProjectVersionRef, String> translateVersions( List<ProjectVersionRef> p ) throws RestException
     {
         final List<ProjectVersionRef> projects = p.stream().distinct().collect( Collectors.toList() );
@@ -419,7 +434,8 @@ public class DefaultTranslator
             {
                 LookupGAVsRequest request =
                                 new LookupGAVsRequest( Collections.emptySet(), Collections.emptySet(), repositoryGroup,
-                                                       incrementalSerialSuffix, GAVUtils.generateGAVs( chunk ) );
+                                                       brewPullActive, mode, incrementalSerialSuffix,
+                                                       GAVUtils.generateGAVs( chunk ) );
 
                 r = Unirest.post( this.endpointUrl )
                            .header( "accept", "application/json" )

--- a/io/src/main/java/org/commonjava/maven/ext/io/rest/DefaultTranslator.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/rest/DefaultTranslator.java
@@ -484,6 +484,9 @@ public class DefaultTranslator
 
                                        logger.debug( "Read message string {}, processed to {} ", originalBody, errorString );
                                    }
+                                   else if (originalBody.startsWith( "javax.validation.ValidationException: " )) {
+                                       this.errorString = originalBody;
+                                   }
                                    else
                                    {
                                        throw new ManipulationUncheckedException( "Problem in HTTP communication with status code {} and message {}",

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/AutoSplitTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/AutoSplitTest.java
@@ -87,8 +87,8 @@ public class AutoSplitTest
 
     private List<List<Map<String, Object>>> translate(int size) {
         final DefaultTranslator versionTranslator = new DefaultTranslator(
-                        mockServer.getUrl(), -1, 0, "",
-                        "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
+                        mockServer.getUrl(), -1, 0, "", null, null,
+                        "", DEFAULT_CONNECTION_TIMEOUT_SEC,
                         DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC);
 
         List<ProjectVersionRef> data = aLotOfGavs.subList( 0, size );

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/BlacklistTranslatorTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/BlacklistTranslatorTest.java
@@ -56,7 +56,7 @@ public class BlacklistTranslatorTest
         LoggerFactory.getLogger( BlacklistTranslatorTest.class ).info( "Executing test " + testName.getMethodName() );
 
         this.blacklistTranslator = new DefaultTranslator( mockServer.getUrl(), 0, Translator.CHUNK_SPLIT_COUNT, "",
-                                                          "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
+                                                          null, null, "", DEFAULT_CONNECTION_TIMEOUT_SEC,
                                                           DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
     }
 

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/HandleServiceUnavailableTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/HandleServiceUnavailableTest.java
@@ -77,7 +77,7 @@ public class HandleServiceUnavailableTest
 
         handler.setStatusCode( HttpServletResponse.SC_SERVICE_UNAVAILABLE );
         versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0, Translator.CHUNK_SPLIT_COUNT,
-                                                   "", "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
+                                                   "", null, null, "", DEFAULT_CONNECTION_TIMEOUT_SEC,
                                                    DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
     }
 
@@ -124,8 +124,9 @@ public class HandleServiceUnavailableTest
         logger.debug( requestData.toString() );
         assertEquals( 6, requestData.size() );
         assertEquals( 37, requestData.get( 0 ).size() );
-        for ( int i = 1; i < 4; i++ )
+        for ( int i = 1; i < 4; i++ ) {
             assertEquals( 9, requestData.get( i ).size() );
+        }
         assertEquals( 10, requestData.get( 4 ).size() );
         assertEquals( 2, requestData.get( 5 ).size() );
 

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/HttpErrorTranslatorTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/HttpErrorTranslatorTest.java
@@ -96,8 +96,8 @@ public class HttpErrorTranslatorTest
         LoggerFactory.getLogger( HttpErrorTranslatorTest.class ).info ( "Executing test " + testName.getMethodName());
 
         this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0,
-                                                        Translator.CHUNK_SPLIT_COUNT, "",
-                                                        "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
+                                                        Translator.CHUNK_SPLIT_COUNT, "", null, null,
+                                                        "", DEFAULT_CONNECTION_TIMEOUT_SEC,
                                                         DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
     }
 

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/HttpHeaderHeaderTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/HttpHeaderHeaderTest.java
@@ -72,8 +72,9 @@ public class HttpHeaderHeaderTest
         LoggerFactory.getLogger( HttpHeaderHeaderTest.class ).info ( "Executing test " + testName.getMethodName());
 
         this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0,
-                                                        Translator.CHUNK_SPLIT_COUNT, "", "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
-                                                        DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
+                                                        Translator.CHUNK_SPLIT_COUNT, "", null, null, "",
+                                                        DEFAULT_CONNECTION_TIMEOUT_SEC, DEFAULT_SOCKET_TIMEOUT_SEC,
+                                                        RETRY_DURATION_SEC );
     }
 
     private String generateResponse()

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/HttpMessageTranslatorTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/HttpMessageTranslatorTest.java
@@ -67,8 +67,9 @@ public class HttpMessageTranslatorTest
         LoggerFactory.getLogger( HttpMessageTranslatorTest.class ).info ( "Executing test " + testName.getMethodName());
 
         this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0,
-                                                        Translator.CHUNK_SPLIT_COUNT, "", "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
-                                                        DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
+                                                        Translator.CHUNK_SPLIT_COUNT, "", null, null, "",
+                                                        DEFAULT_CONNECTION_TIMEOUT_SEC, DEFAULT_SOCKET_TIMEOUT_SEC,
+                                                        RETRY_DURATION_SEC );
     }
 
     @Test

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/RESTHeaderTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/RESTHeaderTest.java
@@ -54,7 +54,7 @@ public class RESTHeaderTest
         headers.put( "Foo", "bar" );
         headers.put( "Bar", "baz" );
         new DefaultTranslator( mockServer.getUrl(), 0,
-                Translator.CHUNK_SPLIT_COUNT, null, "", headers, DEFAULT_CONNECTION_TIMEOUT_SEC, 
+                Translator.CHUNK_SPLIT_COUNT, null, null, null, "", headers, DEFAULT_CONNECTION_TIMEOUT_SEC,
                 DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
     }
 }

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/RESTParametersTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/RESTParametersTest.java
@@ -87,8 +87,9 @@ public class RESTParametersTest
     {
         String group = "indyGroup";
         this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0,
-                                                        Translator.CHUNK_SPLIT_COUNT, group, "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
-                                                        DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
+                                                        Translator.CHUNK_SPLIT_COUNT, group, null, null, "",
+                                                        DEFAULT_CONNECTION_TIMEOUT_SEC, DEFAULT_SOCKET_TIMEOUT_SEC,
+                                                        RETRY_DURATION_SEC );
         List<ProjectVersionRef> gavs = Collections.singletonList(
             new SimpleProjectVersionRef( "com.example", "example", "1.0" ) );
 
@@ -100,8 +101,9 @@ public class RESTParametersTest
     public void testVerifyNoGroup() throws RestException
     {
         this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0,
-                                                        Translator.CHUNK_SPLIT_COUNT, "", "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
-                                                        DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
+                                                        Translator.CHUNK_SPLIT_COUNT, "", null, null, "",
+                                                        DEFAULT_CONNECTION_TIMEOUT_SEC, DEFAULT_SOCKET_TIMEOUT_SEC,
+                                                        RETRY_DURATION_SEC );
         List<ProjectVersionRef> gavs = Collections.singletonList(
             new SimpleProjectVersionRef( "com.example", "example", "1.0" ) );
 

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/RESTParametersVersionSuffixTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/RESTParametersVersionSuffixTest.java
@@ -87,8 +87,9 @@ public class RESTParametersVersionSuffixTest
     {
         String suffix = "rebuild";
         this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0,
-                                                        Translator.CHUNK_SPLIT_COUNT, "", suffix, DEFAULT_CONNECTION_TIMEOUT_SEC,
-                                                        DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
+                                                        Translator.CHUNK_SPLIT_COUNT, "", null, null, suffix,
+                                                        DEFAULT_CONNECTION_TIMEOUT_SEC, DEFAULT_SOCKET_TIMEOUT_SEC,
+                                                        RETRY_DURATION_SEC );
         List<ProjectVersionRef> gavs = Collections.singletonList(
             new SimpleProjectVersionRef( "com.example", "example", "1.0" ) );
 
@@ -100,8 +101,9 @@ public class RESTParametersVersionSuffixTest
     public void testVerifyNoSuffix() throws RestException
     {
         this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0,
-                                                        Translator.CHUNK_SPLIT_COUNT, "", "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
-                                                        DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
+                                                        Translator.CHUNK_SPLIT_COUNT, "", null, null, "",
+                                                        DEFAULT_CONNECTION_TIMEOUT_SEC, DEFAULT_SOCKET_TIMEOUT_SEC,
+                                                        RETRY_DURATION_SEC );
         List<ProjectVersionRef> gavs = Collections.singletonList(
             new SimpleProjectVersionRef( "com.example", "example", "1.0" ) );
 

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/VersionTranslatorSplitTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/VersionTranslatorSplitTest.java
@@ -75,7 +75,7 @@ public class VersionTranslatorSplitTest
 
         handler.setStatusCode( HttpServletResponse.SC_GATEWAY_TIMEOUT );
         versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0, Translator.CHUNK_SPLIT_COUNT,
-                                                   "", "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
+                                                   "", null, null, "", DEFAULT_CONNECTION_TIMEOUT_SEC,
                                                    DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
     }
 
@@ -116,8 +116,9 @@ public class VersionTranslatorSplitTest
         logger.debug( requestData.toString() );
         assertEquals( 6, requestData.size() );
         assertEquals( 37, requestData.get( 0 ).size() );
-        for ( int i = 1; i < 4; i++ )
+        for ( int i = 1; i < 4; i++ ) {
             assertEquals( 9, requestData.get( i ).size() );
+        }
         assertEquals( 10, requestData.get( 4 ).size() );
         assertEquals( 2, requestData.get( 5 ).size() );
 
@@ -153,8 +154,9 @@ public class VersionTranslatorSplitTest
         logger.debug( requestData.toString() );
         assertEquals( 6, requestData.size() );
         assertEquals( 36, requestData.get( 0 ).size() );
-        for ( int i = 1; i < 5; i++ )
+        for ( int i = 1; i < 5; i++ ) {
             assertEquals( 9, requestData.get( i ).size() );
+        }
         assertEquals( 2, requestData.get( 5 ).size() );
 
         Set<Map<String, Object>> original = new HashSet<>( requestData.get( 0 ) );
@@ -171,7 +173,7 @@ public class VersionTranslatorSplitTest
     public void testTranslateVersionsCorrectSplitMaxSize()
     {
         this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 10, Translator.CHUNK_SPLIT_COUNT,
-                                                        "", "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
+                                                        "", null, null, "", DEFAULT_CONNECTION_TIMEOUT_SEC,
                                                         DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
 
         List<ProjectVersionRef> data = aLotOfGavs.subList( 0, 30 );
@@ -234,8 +236,8 @@ public class VersionTranslatorSplitTest
     @Test
     public void testTranslateVersionsCorrectSplitMaxSizeWithMin()
     {
-        this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 10, 1, "",
-                                                        "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
+        this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 10, 1, "", null, null,
+                                                        "", DEFAULT_CONNECTION_TIMEOUT_SEC,
                                                         DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
 
         List<ProjectVersionRef> data = aLotOfGavs.subList( 0, 30 );

--- a/io/src/test/java/org/commonjava/maven/ext/io/rest/VersionTranslatorTest.java
+++ b/io/src/test/java/org/commonjava/maven/ext/io/rest/VersionTranslatorTest.java
@@ -83,7 +83,7 @@ public class VersionTranslatorTest
         LoggerFactory.getLogger( VersionTranslatorTest.class ).info( "Executing test " + testName.getMethodName() );
 
         this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0, Translator.CHUNK_SPLIT_COUNT, "indyGroup",
-                                                        "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
+                                                        null, null, "", DEFAULT_CONNECTION_TIMEOUT_SEC,
                                                         DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
     }
 
@@ -126,7 +126,7 @@ public class VersionTranslatorTest
     public void testTranslateVersionsWithNulls() throws RestException
     {
         this.versionTranslator = new DefaultTranslator( mockServer.getUrl(), 0, Translator.CHUNK_SPLIT_COUNT, "NullBestMatchVersion",
-                                                        "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
+                                                        null, null, "", DEFAULT_CONNECTION_TIMEOUT_SEC,
                                                         DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
         List<ProjectVersionRef> gavs = Arrays.asList(
                         new SimpleProjectVersionRef( "com.example", "example", "1.0" ),
@@ -151,7 +151,7 @@ public class VersionTranslatorTest
         // Some url that doesn't exist used here
         Translator translator = new DefaultTranslator( "http://127.0.0.2", 0,
                                                        Translator.CHUNK_SPLIT_COUNT, "",
-                                                       "", DEFAULT_CONNECTION_TIMEOUT_SEC, 
+                                                       null, null, "", DEFAULT_CONNECTION_TIMEOUT_SEC,
                                                        DEFAULT_SOCKET_TIMEOUT_SEC, RETRY_DURATION_SEC );
 
         List<ProjectVersionRef> gavs = Collections.singletonList(

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
 
     <mavenVersion>3.5.0</mavenVersion>
     <atlasVersion>0.17.1</atlasVersion>
+    <daVersion>2.1.0.Api-1</daVersion>
     <galleyVersion>0.16.6</galleyVersion>
 
     <groovyVersion>3.0.7</groovyVersion>
@@ -266,7 +267,7 @@
       <dependency>
         <groupId>org.jboss.da</groupId>
         <artifactId>reports-model</artifactId>
-        <version>1.7.0</version>
+        <version>${daVersion}</version>
       </dependency>
 
       <!-- Plexus Dependencies Reference: -->


### PR DESCRIPTION
Introduce command line flag restBrewPullActive and new switch restMode. Those are used to determine if the REST service (DA) should use the Brew Pull feature or not and if it should also lookup temporary and/or managed service artifacts or not. This should replace passing of restRepositoryGroup value and the repository group to be used should be determined by DA based on the flags. All of those command line params are passed to the rest service which should ensure it's backwards compatible.