### PR TITLE
Modify shading so library is picked up as core extension

### DIFF
--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -89,12 +89,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
     </dependency>
@@ -172,10 +166,6 @@
         <artifactId>sisu-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>generate-index</id>
-            <phase>none</phase>
-          </execution>
-          <execution>
             <id>index-dependencies</id>
             <phase>prepare-package</phase>
             <goals>
@@ -187,7 +177,6 @@
           </execution>
         </executions>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -201,9 +190,6 @@
               <artifactSet>
                 <includes>
                   <include>org.commonjava.*:*</include>
-                  <include>javax.inject:*</include>
-                  <include>org.eclipse.*:*</include>
-
                   <include>com.fasterxml.jackson.core:*</include>
                   <include>com.jayway.jsonpath:json-path</include>
                   <include>com.konghq:unirest-java</include>
@@ -223,11 +209,21 @@
                   <include>org.codehaus.groovy:groovy</include>
                   <include>org.jboss.da:reports-model</include>
                   <include>org.jdom:jdom</include>
-                  <include>org.jsoup:jsoup</include>
                   <include>org.ow2.asm:asm</include>
                   <include>org.yaml:snakeyaml</include>
                 </includes>
+                <excludes>
+                  <exclude>org.codehaus.plexus:plexus-utils</exclude>
+                </excludes>
               </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>org.apache.maven.release:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/plexus/components.xml</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>

--- a/integration-test/src/it/rest-dependency-version-manip-child-module/settings.xml
+++ b/integration-test/src/it/rest-dependency-version-manip-child-module/settings.xml
@@ -28,7 +28,7 @@
               <repository>
                   <id>rh-repository</id>
                   <name>Red Hat repository (all)</name>
-                  <url>http://maven.repository.redhat.com/ga/</url>
+                  <url>https://maven.repository.redhat.com/ga/</url>
                   <layout>default</layout>
                   <releases>
                       <enabled>true</enabled>
@@ -44,7 +44,7 @@
               <pluginRepository>
                   <id>rh-repository</id>
                   <name>Red Hat repository (all)</name>
-                  <url>http://maven.repository.redhat.com/ga/</url>
+                  <url>https://maven.repository.redhat.com/ga/</url>
                   <layout>default</layout>
                   <releases>
                       <enabled>true</enabled>

--- a/integration-test/src/it/rest-dependency-version-manip-profile/settings.xml
+++ b/integration-test/src/it/rest-dependency-version-manip-profile/settings.xml
@@ -28,7 +28,7 @@
               <repository>
                   <id>rh-repository</id>
                   <name>Red Hat repository (all)</name>
-                  <url>http://maven.repository.redhat.com/ga/</url>
+                  <url>https://maven.repository.redhat.com/ga/</url>
                   <layout>default</layout>
                   <releases>
                       <enabled>true</enabled>
@@ -44,7 +44,7 @@
               <pluginRepository>
                   <id>rh-repository</id>
                   <name>Red Hat repository (all)</name>
-                  <url>http://maven.repository.redhat.com/ga/</url>
+                  <url>https://maven.repository.redhat.com/ga/</url>
                   <layout>default</layout>
                   <releases>
                       <enabled>true</enabled>


### PR DESCRIPTION
For #832

While this PR resolves _detection_ of the extensions there appears to be further classloader issues in that Maven Model classes are loaded within  `ClassRealm[plexus.core` versus `ClassRealm[coreExtension` which causes issues