### PR TITLE
NCLSUP-377: Guard against null plugin version

### DIFF
--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/BaseGroovyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/BaseGroovyManipulator.java
@@ -98,7 +98,7 @@ public abstract class BaseGroovyManipulator
                 for ( final String script : scripts )
                 {
                     File found;
-                    if ( script.startsWith( "http" ) || script.startsWith( "file" ))
+                    if ( script.startsWith( "http" ) || script.startsWith( "file" ) )
                     {
                         logger.info( "Attempting to read URL {}", script );
                         found = fileIO.resolveURL( script );

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/DependencyManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/DependencyManipulator.java
@@ -55,6 +55,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.apache.commons.lang.StringUtils.startsWith;
 import static org.commonjava.maven.ext.core.util.IdUtils.ga;
 
 /**
@@ -641,12 +642,13 @@ public class DependencyManipulator extends CommonManipulator implements Manipula
     private void validateDependenciesUpdatedProperty( CommonState cState, Project p, Map<ArtifactRef, Dependency> dependencies )
                     throws ManipulationException
     {
-        for ( ArtifactRef d : dependencies.keySet() )
+        for ( Entry<ArtifactRef, Dependency> entry : dependencies.entrySet() )
         {
-            String versionProperty = dependencies.get( d ).getVersion();
-            if ( versionProperty.startsWith( "${" ) )
+            String versionProperty = entry.getValue().getVersion();
+
+            if ( startsWith( versionProperty, "${" ) )
             {
-                PropertiesUtils.verifyPropertyMapping( cState, p, versionPropertyUpdateMap, d,
+                PropertiesUtils.verifyPropertyMapping( cState, p, versionPropertyUpdateMap, entry.getKey(),
                                                        PropertiesUtils.extractPropertyName( versionProperty ) );
             }
         }

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/PluginManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/PluginManipulator.java
@@ -54,6 +54,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.apache.commons.lang.StringUtils.startsWith;
+import static org.commonjava.maven.ext.core.impl.Version.isEmpty;
 import static org.commonjava.maven.ext.core.util.IdUtils.ga;
 
 /**
@@ -551,10 +553,13 @@ public class PluginManipulator extends CommonManipulator implements Manipulator
     private void validatePluginsUpdatedProperty( CommonState cState, Project p, Map<ProjectVersionRef, Plugin> dependencies )
                     throws ManipulationException
     {
-        for ( ProjectVersionRef d : dependencies.keySet() )
+        for ( Map.Entry<ProjectVersionRef, Plugin> entry : dependencies.entrySet() )
         {
-            String versionProperty = dependencies.get( d ).getVersion();
-            if ( versionProperty.startsWith( "${" ) )
+            ProjectVersionRef d = entry.getKey();
+            Plugin plugin = entry.getValue();
+            String versionProperty = plugin.getVersion();
+
+            if ( startsWith( versionProperty, "${" ) )
             {
                 versionProperty = PropertiesUtils.extractPropertyName( versionProperty );
                 PropertiesUtils.verifyPropertyMapping( cState, p, versionPropertyUpdateMap, d, versionProperty );

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/ProjectVersioningManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/ProjectVersioningManipulator.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.apache.commons.lang.StringUtils.startsWith;
 
 /**
  * {@link Manipulator} implementation that can modify a project's version with either static or calculated, incremental version qualifier. Snapshot
@@ -163,7 +164,7 @@ public class ProjectVersioningManipulator
             {
                 final String newVersion = versionsByGAV.get( parentGAV );
                 logger.debug( "Changed parent (GAV {}) version to: {}", parent, newVersion );
-                if (parentGAV.getVersionString().startsWith( "${" ))
+                if ( startsWith( parentGAV.getVersionString(), "${" ) )
                 {
                     if ( PropertiesUtils.updateProperties( session, project, false, PropertiesUtils.extractPropertyName( parentGAV.getVersionString() ), newVersion ) == PropertiesUtils.PropertyUpdate.NOTFOUND )
                     {
@@ -185,7 +186,7 @@ public class ProjectVersioningManipulator
             logger.info( "Looking for new version: {} (found: {})", gav, newVersion );
             if ( newVersion != null )
             {
-                if (gav.getVersionString().startsWith( "${" ))
+                if ( startsWith( gav.getVersionString(), "${" ) )
                 {
                     if ( PropertiesUtils.updateProperties( session, project, false, PropertiesUtils.extractPropertyName( gav.getVersionString() ), newVersion ) == PropertiesUtils.PropertyUpdate.NOTFOUND )
                     {
@@ -240,7 +241,7 @@ public class ProjectVersioningManipulator
                         if ( newVersion != null )
                         {
                             logger.debug ("Examining dependency (from depMgmt) {} to change version to {}", d, newVersion);
-                            if (d.getVersion().startsWith( "${" ))
+                            if ( startsWith( d.getVersion(), "${" ) )
                             {
                                 if ( PropertiesUtils.updateProperties( session, project, false, PropertiesUtils.extractPropertyName( d.getVersion() ), newVersion ) == PropertiesUtils.PropertyUpdate.NOTFOUND )
                                 {
@@ -269,7 +270,7 @@ public class ProjectVersioningManipulator
                 {
                     try
                     {
-                        if ( isEmpty (pi.interp( d.getVersion() )))
+                        if ( isEmpty ( pi.interp( d.getVersion() ) ) )
                         {
                             logger.trace( "Skipping dependency {} as empty version.", d );
                             continue;
@@ -283,8 +284,8 @@ public class ProjectVersioningManipulator
 
                         if ( newVersion != null && d.getVersion() != null )
                         {
-                            logger.debug ("Examining dependency {} to change version to {}", d, newVersion);
-                            if (d.getVersion().startsWith( "${" ))
+                            logger.debug( "Examining dependency {} to change version to {}", d, newVersion );
+                            if ( startsWith( d.getVersion(), "${" ) )
                             {
                                 if ( PropertiesUtils.updateProperties( session, project, false, PropertiesUtils.extractPropertyName( d.getVersion() ), newVersion ) == PropertiesUtils.PropertyUpdate.NOTFOUND )
                                 {
@@ -299,7 +300,7 @@ public class ProjectVersioningManipulator
                             changed = true;
                         }
                     }
-                    catch ( InvalidRefException ire)
+                    catch ( InvalidRefException ire )
                     {
                         logger.debug( "Unable to change version for dependency {} due to {}", d, ire );
                         throw ire;

--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/RepoAndReportingRemovalManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/RepoAndReportingRemovalManipulator.java
@@ -256,7 +256,7 @@ public class RepoAndReportingRemovalManipulator
             String url = repo.getUrl();
             // According to https://maven.apache.org/plugins/maven-site-plugin/examples/adding-deploy-protocol.html
             // supported repositories are file, http and https.
-            if (url.startsWith( "file:" ) ||
+            if ( url.startsWith( "file:" ) ||
                 url.startsWith( "http://localhost" ) ||
                 url.startsWith( "https://localhost" ) ||
                 url.startsWith( "http://127.0.0.1" ) ||

--- a/core/src/main/java/org/commonjava/maven/ext/core/util/PropertiesUtils.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/util/PropertiesUtils.java
@@ -41,7 +41,11 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.commons.lang.StringUtils.contains;
+import static org.apache.commons.lang.StringUtils.countMatches;
+import static org.apache.commons.lang.StringUtils.endsWith;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
+import static org.apache.commons.lang.StringUtils.startsWith;
 
 /**
  * Commonly used manipulations / extractions from project / user (CLI) properties.
@@ -72,7 +76,7 @@ public final class PropertiesUtils
             {
                 final String trimmedPropertyName = propertyName.substring( prefixLength );
                 String value = properties.getProperty( propertyName );
-                if ( value != null && value.equals( "true" ) )
+                if ( "true".equals( value ) )
                 {
                     logger.warn( "Work around Brew/Maven bug - removing erroneous 'true' value for {}.",
                                  trimmedPropertyName );
@@ -152,8 +156,8 @@ public final class PropertiesUtils
         // >${foo}value<
         // it becomes hairy to verify strict compliance and to correctly split the old value and
         // update it with a portion of the new value.
-        if ( oldValue != null && oldValue.startsWith( "${" ) && oldValue.endsWith( "}" ) && !(
-                        StringUtils.countMatches( oldValue, "${" ) > 1 ) )
+        if ( startsWith( oldValue, "${" ) && endsWith( oldValue, "}" ) && !(
+                        countMatches( oldValue, "${" ) > 1 ) )
         {
             final String newKey = oldValue.substring( 2, oldValue.length() - 1 );
 
@@ -189,8 +193,8 @@ public final class PropertiesUtils
             }
 
             // TODO: Does not handle explicit overrides.
-            if ( oldValue != null && oldValue.contains( "${" ) && !( oldValue.startsWith( "${" ) && oldValue.endsWith(
-                            "}" ) ) || ( StringUtils.countMatches( oldValue, "${" ) > 1 ) )
+            if ( contains( oldValue, "${" ) && !( startsWith( oldValue, "${" ) && endsWith( oldValue,
+                            "}" ) ) || ( countMatches( oldValue, "${" ) > 1 ) )
             {
                 // This block handles
                 // >${foo}value${foo}<
@@ -405,15 +409,15 @@ public final class PropertiesUtils
         final Map<String, PropertyMapper> projectProps = versionPropertyUpdateMap.computeIfAbsent( project, k -> new HashMap<>() );
         boolean result = false;
 
-        if ( oldVersion != null && oldVersion.contains( "${" ) )
+        if ( contains( oldVersion, "${" ) )
         {
             final int endIndex = oldVersion.indexOf( '}' );
             final String oldProperty = oldVersion.substring( 2, endIndex );
 
             // We don't attempt to cache any value that contains more than one property or contains a property
             // combined with a hardcoded value.
-            if ( oldVersion.contains( "${" ) && !( oldVersion.startsWith( "${" ) && oldVersion.endsWith( "}" ) ) || (
-                            StringUtils.countMatches( oldVersion, "${" ) > 1 ) )
+            if ( !( startsWith( oldVersion, "${" ) && endsWith( oldVersion, "}" ) ) || (
+                            countMatches( oldVersion, "${" ) > 1 ) )
             {
                 logger.debug( "For {} ; original version contains hardcoded value or multiple embedded properties. Not caching value ( {} -> {} )",
                               originalType, oldVersion, newVersion );

--- a/integration-test/src/it/remote-plugin-management-plugins/test.properties
+++ b/integration-test/src/it/remote-plugin-management-plugins/test.properties
@@ -22,3 +22,4 @@ projectMetaSkip=true
 projectSrcSkip=true
 overrideTransitive=false
 strictAlignment=false
+strictPropertyValidation=true

--- a/integration-test/src/it/remote-plugin-management-transitive/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-transitive/pom.xml
@@ -45,4 +45,19 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/integration-test/src/it/remote-plugin-management-transitive/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-transitive/verify.groovy
@@ -25,4 +25,4 @@ pomFile.eachLine {
    }
 }
 
-assert message == 0
+assert message == 2

--- a/io/src/main/java/org/commonjava/maven/ext/io/ModelIO.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/ModelIO.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
+import static org.apache.commons.lang.StringUtils.startsWith;
 
 /**
  * Class to resolve artifact descriptors (pom files) from a maven repository
@@ -255,12 +256,12 @@ public class ModelIO
                 Plugin p = plit.next();
                 ProjectRef pr = new SimpleProjectRef( p.getGroupId(), p.getArtifactId() );
 
-                if ( ( isNotEmpty( p.getVersion() ) && p.getVersion().startsWith( "${" ) ) || isEmpty( p.getVersion() ) )
+                if ( isEmpty( p.getVersion() ) || startsWith( p.getVersion(), "${" ) )
                 {
                     // Property reference to something in the remote pom. Resolve and inline it now.
                     String newVersion = resolveProperty( userProperties, m.getProperties(), p.getVersion() );
 
-                    if ( newVersion.startsWith("${") || newVersion.length() == 0)
+                    if ( isEmpty( newVersion ) || startsWith( newVersion, "${" ) )
                     {
                         // Use PomView as that contains a pre-resolved list of plugins.
                         newVersion = pluginOverridesPomView.get( pr ).getVersionString();
@@ -298,7 +299,7 @@ public class ModelIO
                 {
                     for ( Dependency d : p.getDependencies())
                     {
-                        if ( ! isEmpty(d.getVersion()) && d.getVersion().startsWith( "${" ) )
+                        if ( startsWith( d.getVersion(), "${" ) )
                         {
                             final String version = resolveProperty( userProperties, m.getProperties(), d.getVersion() );
                             logger.debug( "Processing dependency {} and updating with {}", d, version );
@@ -336,11 +337,11 @@ public class ModelIO
             {
                 processChildren( userProperties, model, child );
             }
-            if ( child.getValue() != null && child.getValue().startsWith( "${" ) )
+            if ( startsWith( child.getValue(), "${" ) )
             {
                 String replacement = resolveProperty( userProperties, model.getProperties(), child.getValue() );
 
-                if ( replacement != null && !replacement.isEmpty() )
+                if ( !isEmpty( replacement ) )
                 {
                     logger.debug( "Replacing child value {} with {}", child.getValue(), replacement );
                     child.setValue( replacement );
@@ -362,7 +363,7 @@ public class ModelIO
         {
             result = p.getProperty( child );
 
-            if ( result.startsWith( "${" ) )
+            if ( startsWith( result, "${" ) )
             {
                 result = resolveProperty( userProperties, p, result );
             }

--- a/io/src/main/java/org/commonjava/maven/ext/io/rest/DefaultTranslator.java
+++ b/io/src/main/java/org/commonjava/maven/ext/io/rest/DefaultTranslator.java
@@ -423,7 +423,7 @@ public class DefaultTranslator
                                {
                                    String originalBody = failedResponse.getParsingError().get().getOriginalBody();
 
-                                   if ( originalBody.length() == 0 )
+                                   if ( originalBody.isEmpty() )
                                    {
                                        this.errorString = "No content to read.";
                                    }
@@ -441,7 +441,8 @@ public class DefaultTranslator
 
                                        logger.debug( "Read message string {}, processed to {}", originalBody, errorString );
                                    }
-                                   else if (originalBody.startsWith( "javax.validation.ValidationException: " )) {
+                                   else if ( originalBody.startsWith( "javax.validation.ValidationException: " ) )
+                                   {
                                        this.errorString = originalBody;
                                    }
                                    else


### PR DESCRIPTION
We have a `Map<ProjectVersionRef, Plugin>` where `plugin.getVersion()` is `null`. As seen below, the `plugin` value has no version specified in the POM. However, the key `projectVersionRef` has a version specified (`org.apache.maven.plugins:maven-surefire-plugin:2.12.4`).

```
            <pluginManagement>
                <plugin>
                    <groupId>org.apache.maven.plugins</groupId>
                    <artifactId>maven-surefire-plugin</artifactId>
                    <configuration>
                        <forkMode>once</forkMode>
                        <argLine>-Djava.awt.headless=true ${surefire.memory.settings}</argLine>
                        <runOrder>alphabetical</runOrder>
                    </configuration>
                </plugin>
            </pluginMangement>
```