### PR TITLE
Delay pom existence check until preparseGroovyManipulator is applied

### DIFF
--- a/cli/src/main/java/org/commonjava/maven/ext/cli/Cli.java
+++ b/cli/src/main/java/org/commonjava/maven/ext/cli/Cli.java
@@ -222,13 +222,8 @@ public class Cli implements Callable<Integer>
             logger.info( "Manipulation engine disabled via command-line option" );
             return 0;
         }
-        if ( !target.exists() )
-        {
-            logger.info( "Manipulation engine disabled. Project {} cannot be found.", target );
-            return 10;
-        }
         // Don't bother skipping if we're just trying to analyse dependencies/print manipulator order.
-        else if ( new File( target.getParentFile(), ManipulationManager.MARKER_FILE ).exists() && !printManipulatorOrder && !printProjectDeps)
+        if ( new File( target.getParentFile(), ManipulationManager.MARKER_FILE ).exists() && !printManipulatorOrder && !printProjectDeps)
         {
             logger.info( "Skipping manipulation as previous execution found." );
             return 0;

--- a/cli/src/test/resources/test.pom
+++ b/cli/src/test/resources/test.pom
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
+
+  <groupId>org.goots</groupId>
+  <artifactId>project</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0.0</version>
+  <name>project</name>
+</project>

--- a/core/src/main/java/org/commonjava/maven/ext/core/ManipulationManager.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/ManipulationManager.java
@@ -205,6 +205,11 @@ public class ManipulationManager
     {
         preparseGroovyManipulator.applyChanges( session );
 
+        if ( !session.getPom().exists() )
+        {
+            throw new ManipulationException( "Manipulation engine disabled. Project {} cannot be found.", session.getPom() );
+        }
+
         final List<Project> currentProjects = pomIO.parseProject( session.getPom() );
         final List<Project> originalProjects = new ArrayList<>(  );
         currentProjects.forEach( p -> originalProjects.add( new Project( p ) ) );


### PR DESCRIPTION
It would be useful to delay the check for the existence of a project POM until after the PREPARE Groovy script(s) have been called.