### PR TITLE
Remove coverage from snapshot builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,5 +98,3 @@ jobs:
             }]
     - name: Deploy Snapshot
       run: mvn -B -V org.apache.maven.plugins:maven-source-plugin:jar-no-fork deploy -Prun-its
-    - name: Codecov
-      uses: codecov/codecov-action@v3


### PR DESCRIPTION
We really only need coverage verification on the main PR request builds.

See also https://github.com/project-ncl/gradle-manipulator/pull/444
