### PR TITLE
Clarify docs for destination of dependencyInjection GAVs

### DIFF
--- a/guide/dep-manip.md
+++ b/guide/dep-manip.md
@@ -367,7 +367,7 @@ file containing a comma or newline separated list of GAs.
 ### Dependency Injection
 
 If the property `-DdependencyInjection=group:artifact:version,....` is set, PME will inject the
-specified dependency into the top level (inheritance root) POM files. The argument should be a
+specified dependency into the top level (inheritance root) POM files' `<dependencyManagement>` sections. The argument should be a
 comma separated list of group:artifact:version. The list also supports a remote HTTP file containing a comma or
 newline separated list of GAVs. The injection dependencies <b>are</b> subject to
 alignment.


### PR DESCRIPTION
The way the documentation is worded, it makes it sound like `-DdependencyInjection` adds a real dependency entry to the POMs. In fact it adds a dependencyManagement entry, as seen in the code here:

https://github.com/release-engineering/pom-manipulation-ext/blob/main/core/src/main/java/org/commonjava/maven/ext/core/impl/DependencyInjectionManipulator.java#L95