### PR TITLE
Add support for type, classifier, and scope with `dependencyInjection`

### DIFF
--- a/core/src/main/java/org/commonjava/maven/ext/core/impl/DependencyInjectionManipulator.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/impl/DependencyInjectionManipulator.java
@@ -19,7 +19,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
-import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.ext.common.ManipulationException;
 import org.commonjava.maven.ext.common.model.Project;
 import org.commonjava.maven.ext.core.ManipulationSession;
@@ -29,10 +28,8 @@ import org.slf4j.LoggerFactory;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -87,7 +84,7 @@ public class DependencyInjectionManipulator
             logger.info( "Applying injection changes to {}", project );
 
             DependencyManagement dependencyManagement = project.getModel().getDependencyManagement();
-            List<Dependency> dependencies = getDependencies( state.getDependencyInjection() );
+            List<Dependency> dependencies = state.getDependencyInjection();
             if ( dependencyManagement == null )
             {
                 dependencyManagement = new DependencyManagement();
@@ -121,10 +118,10 @@ public class DependencyInjectionManipulator
                     if ( execution != null )
                     {
                         Xpp3Dom originalConfiguration = (Xpp3Dom) execution.getConfiguration();
-                        for ( ProjectVersionRef pvr : state.getDependencyInjection() )
+                        for ( Dependency dep : state.getDependencyInjection() )
                         {
                             Xpp3Dom ignoreToAdd = new Xpp3Dom( "ignoredUnusedDeclaredDependency" );
-                            ignoreToAdd.setValue( pvr.getGroupId() + ":" + pvr.getArtifactId() );
+                            ignoreToAdd.setValue( dep.getGroupId() + ":" + dep.getArtifactId() );
                             Xpp3Dom ignoredUnusedDeclaredDeps;
 
                             if (originalConfiguration == null)
@@ -151,20 +148,6 @@ public class DependencyInjectionManipulator
         } );
 
         return changed;
-    }
-    private List<Dependency> getDependencies( List<ProjectVersionRef> pvr )
-    {
-        List<Dependency> results = new ArrayList<>(  );
-
-        for ( ProjectVersionRef p : pvr )
-        {
-            Dependency d = new Dependency();
-            d.setGroupId( p.getGroupId() );
-            d.setArtifactId( p.getArtifactId() );
-            d.setVersion( p.getVersionString() );
-            results.add( d );
-        }
-        return results;
     }
 
     @Override

--- a/core/src/test/java/org/commonjava/maven/ext/core/impl/DependencyInjectionManipulatorTest.java
+++ b/core/src/test/java/org/commonjava/maven/ext/core/impl/DependencyInjectionManipulatorTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.ext.core.impl;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.commonjava.maven.atlas.ident.ref.InvalidRefException;
+import org.commonjava.maven.ext.common.ManipulationException;
+import org.commonjava.maven.ext.common.model.Project;
+import org.commonjava.maven.ext.core.ManipulationSession;
+import org.junit.Test;
+
+import static org.commonjava.maven.ext.core.fixture.TestUtils.createSession;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class DependencyInjectionManipulatorTest extends DependencyInjectionManipulator {
+
+    private DependencyInjectionManipulator manipulator;
+    private Properties sessionProperties;
+    private ManipulationSession session;
+
+    void initialize(String dependencyInjection) throws ManipulationException {
+        sessionProperties = new Properties( );
+        sessionProperties.put("dependencyInjection", dependencyInjection);
+
+        session = createSession( sessionProperties );
+
+        manipulator = new DependencyInjectionManipulator();
+        manipulator.init(session);
+    }
+
+    static Model model(boolean initDepMgmt) {
+        Model model = new Model();
+        model.setGroupId(UUID.randomUUID().toString());
+        model.setArtifactId(UUID.randomUUID().toString());
+        model.setVersion("1.0");
+        if (initDepMgmt) {
+            model.setDependencyManagement(new DependencyManagement());
+        }
+        return model;
+    }
+
+    static Project newProject(boolean initDepMgmt) throws ManipulationException {
+        Project project = new Project(model(initDepMgmt));
+        project.setInheritanceRoot(true);
+        return project;
+    }
+
+    @Test
+    public void testDependencyInjectedWithoutDepMgmt() throws ManipulationException {
+        testDependencyInjected3Part(false);
+    }
+
+    @Test
+    public void testDependencyInjectedWithDepMgmt() throws ManipulationException {
+        testDependencyInjected3Part(true);
+    }
+
+    private void testDependencyInjected3Part(boolean initDepMgmt) throws ManipulationException {
+        Dependency managed = inject("grp1:art1:ver1", initDepMgmt);
+        assertEquals("grp1", managed.getGroupId());
+        assertEquals("art1", managed.getArtifactId());
+        assertEquals("ver1", managed.getVersion());
+    }
+
+    @Test
+    public void testDependencyInjected4Part() throws ManipulationException {
+        Dependency managed = inject("grp1:art1:typ1:ver1");
+        assertEquals("grp1", managed.getGroupId());
+        assertEquals("art1", managed.getArtifactId());
+        assertEquals("typ1", managed.getType());
+        assertEquals("ver1", managed.getVersion());
+    }
+
+    @Test
+    public void testDependencyInjected5Part() throws ManipulationException {
+        Dependency managed = inject("grp1:art1:typ1:cls1:ver1");
+        assertEquals("grp1", managed.getGroupId());
+        assertEquals("art1", managed.getArtifactId());
+        assertEquals("typ1", managed.getType());
+        assertEquals("cls1", managed.getClassifier());
+        assertEquals("ver1", managed.getVersion());
+    }
+
+    @Test
+    public void testDependencyInjected6Part() throws ManipulationException {
+        Dependency managed = inject("grp1:art1:typ1:cls1:ver1:scp1");
+        assertEquals("grp1", managed.getGroupId());
+        assertEquals("art1", managed.getArtifactId());
+        assertEquals("typ1", managed.getType());
+        assertEquals("cls1", managed.getClassifier());
+        assertEquals("ver1", managed.getVersion());
+        assertEquals("scp1", managed.getScope());
+    }
+
+    @Test
+    public void testDependencyInjectedInvalid() {
+        assertThrows(InvalidRefException.class, () -> inject("grp1:art1")); // too short
+        assertThrows(InvalidRefException.class, () -> inject(":art1:ver1")); // missing groupId
+        assertThrows(InvalidRefException.class, () -> inject("grp1::ver1")); // missing artifactId
+        assertThrows(InvalidRefException.class, () -> inject("grp1:art1:")); // missing version
+        assertThrows(InvalidRefException.class, () -> inject("grp1:art1:typ1:cls1:ver1:scp1:foo1")); // too long
+    }
+
+    private Dependency inject(String dependencyInjection) throws ManipulationException {
+        return inject(dependencyInjection, false);
+    }
+
+    private Dependency inject(String dependencyInjection, boolean initDepMgmt) throws ManipulationException {
+        initialize(dependencyInjection);
+
+        List<Project> projects = Arrays.asList(newProject(initDepMgmt));
+        Set<Project> updatedProjects = manipulator.applyChanges(projects);
+        assertEquals(1, updatedProjects.size());
+
+        Model model = updatedProjects.iterator().next().getModel();
+        DependencyManagement mgmt = model.getDependencyManagement();
+        assertEquals(1, mgmt.getDependencies().size());
+
+        return mgmt.getDependencies().get(0);
+    }
+}


### PR DESCRIPTION
Allows for the injection of managed dependencies that need to specify `type`, `scope`, and/or `classifier`. For example when adding a BOM that requires `type` of `pom` and `scope` of `import`.